### PR TITLE
Update libgnome-keyring and libsoup

### DIFF
--- a/modulesets-stable/gtk-osx-unsupported.modules
+++ b/modulesets-stable/gtk-osx-unsupported.modules
@@ -87,6 +87,7 @@ This issue was closed by revision r827.
       <dep package="glib"/>
       <dep package="libgcrypt"/>
       <dep package="libtasn1"/>
+      <dep package="dbus"/>
     </dependencies>
   </autotools>
 


### PR DESCRIPTION
Libgnome-keyring doesn't need to be split into GTK 3 and non-GTK 3
versions; it doesn't use GTK anymore apparently, and builds with any
GLib >= 2.16.

Libsoup can then be updated to 2.34 for the 2.28 version of GLib.
Also, libsoup eliminated some dependencies starting with 2.34. So
GConf doesn't have to be built anymore.
