### PR TITLE
Use configure for vala-bootstrap, not autogen.sh

### DIFF
--- a/modulesets/gtk-osx-random.modules
+++ b/modulesets/gtk-osx-random.modules
@@ -76,7 +76,7 @@
 -->
 
 <!-- Vala-bootstrap is the current stable vala precompiled to C. -->
-  <autotools id="vala">
+  <autotools id="vala" autogen-sh="configure">
     <branch module="vala-bootstrap"/>
   </autotools>
 


### PR DESCRIPTION
vala-bootstrap's `autogen.sh` doesn't automatically run `configure`,
so the build breaks for lack of a `Makefile`. In addition,
vala-bootstrap already includes `configure`, so `autogen.sh` isn't
necessary.
