### PR TITLE
Change libproxy branch to tag

### DIFF
--- a/modulesets/gtk-osx-unsupported.modules
+++ b/modulesets/gtk-osx-unsupported.modules
@@ -76,7 +76,7 @@
   </autotools>
 
   <cmake id='libproxy' cmakeargs="-DWITH_PYTHON=OFF">
-    <branch revision="libproxy-0.4.10"
+    <branch tag="libproxy-0.4.10"
             repo='libproxy.google.com'/>
     <dependencies>
       <dep package="cmake"/>


### PR DESCRIPTION
Libproxy is a SVN repository, so when checking out a tag we have to
specify tag instead of revision.
