### PR TITLE
Preserve previous $CFLAGS for liboil

### DIFF
--- a/modulesets-stable/gtk-osx-gstreamer.modules
+++ b/modulesets-stable/gtk-osx-gstreamer.modules
@@ -12,7 +12,7 @@
 	      href="http://code.entropywave.com/download/"/>
 
   <autotools id="liboil" autogen-template="autoreconf -fis &amp;&amp; %(srcdir)s/configure --prefix %(prefix)s --libdir %(libdir)s %(autogenargs)s"
-	     makeargs=" CFLAGS=-DHAVE_SYMBOL_UNDERSCORE">
+	     makeargs=' CFLAGS="$CFLAGS -DHAVE_SYMBOL_UNDERSCORE"'>
     <branch repo="liboil" module="liboil-0.3.17.tar.gz" version="0.3.17" />
   </autotools>
 

--- a/modulesets-unstable/gtk-osx-gstreamer.modules
+++ b/modulesets-unstable/gtk-osx-gstreamer.modules
@@ -16,7 +16,7 @@
        git://anongit.freedesktop.org/gstreamer/jhbuild/. The modules
        are unversioned and haven't been tested for gtk-osx
        compatibility, but there are more of them. -->
-  <autotools id="liboil" makeargs=" CFLAGS=-DHAVE_SYMBOL_UNDERSCORE">
+  <autotools id="liboil" makeargs=' CFLAGS="$CFLAGS -DHAVE_SYMBOL_UNDERSCORE"'>
     <branch repo="liboil"  />
   </autotools>
 

--- a/modulesets/gtk-osx-gstreamer.modules
+++ b/modulesets/gtk-osx-gstreamer.modules
@@ -16,7 +16,7 @@
        git://anongit.freedesktop.org/gstreamer/jhbuild/. The modules
        are unversioned and haven't been tested for gtk-osx
        compatibility. -->
-  <autotools id="liboil" makeargs=" CFLAGS=-DHAVE_SYMBOL_UNDERSCORE">
+  <autotools id="liboil" makeargs=' CFLAGS="$CFLAGS -DHAVE_SYMBOL_UNDERSCORE"'>
     <branch repo="liboil" tag="liboil-0.3.17" />
   </autotools>
 


### PR DESCRIPTION
If the existing CFLAGS are clobbered and replaced with
-DHAVE_SYMBOL_UNDERSCORE, then a 64-bit compiler will be used on
a 64-bit system even if a 32-bit compiler has been specified. This
causes the build to fail when it tries to compile 32-bit assembly
language.
