### PR TITLE
gtk+-2.24.16 requires libtool 2.4.2

### DIFF
--- a/modulesets-stable/bootstrap.modules
+++ b/modulesets-stable/bootstrap.modules
@@ -78,7 +78,7 @@
 
   <autotools id="libtool" autogen-sh="configure">
     <branch repo="ftp.gnu.org"
-            module="libtool/libtool-2.4.tar.gz" version="2.4"/>
+            module="libtool/libtool-2.4.2.tar.gz" version="2.4.2"/>
   </autotools>
 
   <autotools id="automake-1.10" autogen-sh="configure">


### PR DESCRIPTION
Hello,

I was requested to run autoreconf --force because gtk+-2.24.16 requires libtool 2.4.2. Please check this.

Thanks
