### PR TITLE
Partial fix for freetype: disable bzip2

### DIFF
--- a/modulesets-unstable/gtk-osx-bootstrap.modules
+++ b/modulesets-unstable/gtk-osx-bootstrap.modules
@@ -133,7 +133,7 @@
 
 
   <autotools id="freetype" skip-autogen="never"
-	     autogen-template="%(srcdir)s/%(autogen-sh)s &amp;&amp; %(srcdir)s/configure --prefix %(prefix)s --libdir %(libdir)s %(autogenargs)s"
+	     autogen-template="%(srcdir)s/%(autogen-sh)s &amp;&amp; %(srcdir)s/configure --prefix %(prefix)s --libdir %(libdir)s %(autogenargs)s --without-bzip2"
 	     supports-non-srcdir-builds="no">
     <branch module="freetype/freetype2" repo="nongnu"/>
     <dependencies>


### PR DESCRIPTION
bzip2 fonts aren't needed here and it doesn't build, take it out

Still doesn't actually build because harfbuzz doesn't build hb-ft due to circular dependency...
