### PR TITLE
Update vala to latest stable

### DIFF
--- a/modulesets-stable/gtk-osx-random.modules
+++ b/modulesets-stable/gtk-osx-random.modules
@@ -81,9 +81,10 @@ Libglade itself is deprecated. This is the last release. -->
     </dependencies>
   </autotools>
 
-    <autotools id="vala" autogen-sh="configure">
-    <branch repo="ftp.gnome.org" module="vala/0.18/vala-0.18.0.tar.xz"
-            version="0.18.0" hash="sha256:18cb2220ce7352a9dd71be058530f7d4a6c8215a1d9c471430af60a04496a60b"/>
+  <autotools id="vala" autogen-sh="configure">
+    <branch repo="ftp.gnome.org" version="0.26.0"
+            module="vala/0.26/vala-0.26.0.tar.xz"
+            hash="sha256:c1d0a6a485d5cbfbe027483adfc5f7c80c2404b692375be80d75193d915dcd2f"/>
     <after>
       <dep package="meta-gtk-osx-bootstrap"/>
       <dep package="meta-gtk-osx-core"/>

--- a/modulesets-unstable/gtk-osx-random.modules
+++ b/modulesets-unstable/gtk-osx-random.modules
@@ -76,8 +76,14 @@
     </dependencies>
   </autotools>
 <!-- Vala-bootstrap is the current stable vala precompiled to C. -->
-  <autotools id="vala" autogen-sh="configure">
+  <!--<autotools id="vala" autogen-sh="configure">
     <branch module="vala-bootstrap"/>
+  </autotools>-->
+  <!-- vala-bootstrap is stuck at 0.16, so use a tarball for the time being.-->
+  <autotools id="vala" autogen-sh="configure">
+    <branch repo="ftp.gnome.org" version="0.26.0"
+            module="vala/0.26/vala-0.26.0.tar.xz"
+            hash="sha256:c1d0a6a485d5cbfbe027483adfc5f7c80c2404b692375be80d75193d915dcd2f"/>
   </autotools>
 <!-- Vala is written in vala, so you need vala to build it. If you
      want to work on vala itself or need the bleeding edge for some

--- a/modulesets/gtk-osx-random.modules
+++ b/modulesets/gtk-osx-random.modules
@@ -79,8 +79,14 @@
 -->
 
 <!-- Vala-bootstrap is the current stable vala precompiled to C. -->
-  <autotools id="vala" autogen-sh="configure">
+  <!--<autotools id="vala" autogen-sh="configure">
     <branch module="vala-bootstrap"/>
+  </autotools>-->
+  <!-- vala-bootstrap is stuck at 0.16, so use a tarball for the time being.-->
+  <autotools id="vala" autogen-sh="configure">
+    <branch repo="ftp.gnome.org" version="0.26.0"
+            module="vala/0.26/vala-0.26.0.tar.xz"
+            hash="sha256:c1d0a6a485d5cbfbe027483adfc5f7c80c2404b692375be80d75193d915dcd2f"/>
   </autotools>
 
   <autotools id="unique">


### PR DESCRIPTION
This updates modulesets-stable to use Vala 0.26. The other module sets
were supposed to use the vala-bootstrap repository, but that is stuck
at 0.16 and is probably not going to be updated anymore, so use the
tarball of Vala 0.26 for the other module sets as well.
