### PR TITLE
Don't try to patch .gitignore in tarball

### DIFF
--- a/patches/gjs-Bug-740696-Use-m4-directory-for-macros.patch
+++ b/patches/gjs-Bug-740696-Use-m4-directory-for-macros.patch
@@ -11,23 +11,10 @@ there.
 
 https://bugzilla.gnome.org/show_bug.cgi?id=740696
 ---
- .gitignore   | 1 +
  Makefile.am  | 2 +-
  configure.ac | 1 +
- 3 files changed, 3 insertions(+), 1 deletion(-)
+ 2 files changed, 2 insertions(+), 1 deletion(-)
 
-diff --git a/.gitignore b/.gitignore
-index 85de3e8..3f203a7 100644
---- a/.gitignore
-+++ b/.gitignore
-@@ -31,6 +31,7 @@ gjs_gi_probes.h
- install-sh
- libtool
- ltmain.sh
-+/m4
- missing
- stamp-h1
- test_user_data
 diff --git a/Makefile.am b/Makefile.am
 index 4dbd318..ff2c008 100644
 --- a/Makefile.am


### PR DESCRIPTION
Copying this patch from a git commit didn't quite work, as it tries to
patch .gitignore. That file is of course not present in a tarball.
