### PR TITLE
Update crypto stack

### DIFF
--- a/modulesets-stable/gtk-osx-unsupported.modules
+++ b/modulesets-stable/gtk-osx-unsupported.modules
@@ -75,6 +75,18 @@
     </dependencies>
   </autotools>
 
+  <!-- Rudely demands TeX to build documentation -->
+  <!-- Assembler files are missing md5-compress.asm for x86_64 -->
+  <autotools id="libnettle" autogen-sh="configure"
+       autogenargs="--disable-documentation --disable-assembler">
+    <!-- gnutls 3.3.x does not support nettle 3.0 -->
+    <branch repo="ftp.gnu.org" version="2.7.1"
+            module="nettle/nettle-2.7.1.tar.gz"/>
+    <dependencies>
+      <dep package="gmp"/>
+    </dependencies>
+  </autotools>
+
   <!-- This is the last version of gnutls that will support libgcrypt;
   subsequent ones require nettle and gmp -->
   <autotools id="gnutls" autogen-sh="configure"

--- a/modulesets-stable/gtk-osx-unsupported.modules
+++ b/modulesets-stable/gtk-osx-unsupported.modules
@@ -23,6 +23,8 @@
               href="http://www.webkitgtk.org/releases/"/>
   <repository type='tarball' name='icu'
 	      href='http://download.icu-project.org/files/'/>
+  <repository type="tarball" name="p11-glue"
+              href="http://p11-glue.freedesktop.org/releases/"/>
 
   <metamodule id="meta-gtk-osx-unsupported">
     <dependencies>
@@ -65,13 +67,22 @@
             module="libpng/zlib-1.2.8.tar.xz"/>
   </autotools>
 
+  <autotools id="p11-kit" autogen-sh="configure"
+             autogenargs="--without-trust-paths">
+    <branch repo="p11-glue" version="0.22.1" module="p11-kit-0.22.1.tar.gz"/>
+    <dependencies>
+      <dep package="libtasn1"/>
+    </dependencies>
+  </autotools>
+
   <!-- This is the last version of gnutls that will support libgcrypt;
   subsequent ones require nettle and gmp -->
   <autotools id="gnutls" autogen-sh="configure"
-	     autogenargs="--with-libgcrypt --without-p11-kit">
+             autogenargs="--with-libgcrypt">
     <branch repo='ftp.gnu.org' version='2.12.20'
             module="gnutls/gnutls-2.12.20.tar.bz2"/>
     <dependencies>
+      <dep package="p11-kit"/>
       <dep package="libgcrypt" />
       <dep package="libtasn1" />
       <dep package="zlib"/>

--- a/modulesets-stable/gtk-osx-unsupported.modules
+++ b/modulesets-stable/gtk-osx-unsupported.modules
@@ -25,6 +25,7 @@
 	      href='http://download.icu-project.org/files/'/>
   <repository type="tarball" name="p11-glue"
               href="http://p11-glue.freedesktop.org/releases/"/>
+  <repository type="tarball" name="gnutls" href="ftp://ftp.gnutls.org/"/>
 
   <metamodule id="meta-gtk-osx-unsupported">
     <dependencies>
@@ -87,15 +88,13 @@
     </dependencies>
   </autotools>
 
-  <!-- This is the last version of gnutls that will support libgcrypt;
-  subsequent ones require nettle and gmp -->
   <autotools id="gnutls" autogen-sh="configure"
-             autogenargs="--with-libgcrypt">
-    <branch repo='ftp.gnu.org' version='2.12.20'
-            module="gnutls/gnutls-2.12.20.tar.bz2"/>
+             autogenargs="--disable-gtk-doc-html">
+    <branch repo="gnutls" version="3.3.12"
+            module="gcrypt/gnutls/v3.3/gnutls-3.3.12.tar.xz"/>
     <dependencies>
       <dep package="p11-kit"/>
-      <dep package="libgcrypt" />
+      <dep package="libnettle"/>
       <dep package="libtasn1" />
       <dep package="zlib"/>
     </dependencies>

--- a/modulesets-stable/gtk-osx-unsupported.modules
+++ b/modulesets-stable/gtk-osx-unsupported.modules
@@ -159,8 +159,8 @@
   </autotools>
 
   <autotools id="libgcrypt" autogen-sh="configure" autogenargs="--disable-asm">
-    <branch repo="ftp.gnupg.org" version="1.5.4"
-            module="gcrypt/libgcrypt/libgcrypt-1.5.4.tar.bz2"/>
+    <branch repo="ftp.gnupg.org" version="1.6.2"
+            module="gcrypt/libgcrypt/libgcrypt-1.6.2.tar.bz2"/>
     <dependencies>
       <dep package="libgpg-error" />
     </dependencies>

--- a/modulesets-stable/gtk-osx-unsupported.modules
+++ b/modulesets-stable/gtk-osx-unsupported.modules
@@ -121,12 +121,11 @@
     </dependencies>
   </autotools>
 
-  <!-- 2.42 requires gnutls 3.0 -->
   <autotools id="glib-networking" autogen-sh="configure"
 	     autogenargs="--without-ca-certificates set_more_warnings=no">
-    <branch module="glib-networking/2.40/glib-networking-2.40.1.tar.xz"
-            hash="sha256:9fb3e54d049a480afdb814ff7452e7ab67e5d5f607ade230d7713f19922b5a28"
-            version="2.40.1"/>
+    <branch module="glib-networking/2.42/glib-networking-2.42.1.tar.xz"
+            hash="sha256:c06bf76da3353695fcc791b7b02e5d60c01c379e554f7841dc6cbca32f65f3a0"
+            version="2.42.1"/>
     <dependencies>
       <dep package="gnutls"/>
     </dependencies>

--- a/modulesets-stable/gtk-osx-unsupported.modules
+++ b/modulesets-stable/gtk-osx-unsupported.modules
@@ -158,8 +158,8 @@
 
   <autotools id="libtasn1" supports-non-srcdir-builds="no"
 	     autogen-sh="configure">
-    <branch repo="ftp.gnu.org" version='2.14'
-	    module="libtasn1/libtasn1-2.14.tar.gz"/>
+    <branch repo="ftp.gnu.org" version="4.2"
+	    module="libtasn1/libtasn1-4.2.tar.gz"/>
   </autotools>
 
    <!-- 10.5 has 7.16.3, which is too old for some things. Otherwise can be skipped. -->

--- a/modulesets-unstable/gtk-osx-unsupported.modules
+++ b/modulesets-unstable/gtk-osx-unsupported.modules
@@ -7,7 +7,6 @@
   <repository type='git' name='git.gnu.org' 
               href="git://git.savannah.gnu.org/"/>
   <repository type='git' name='git.gnupg.org' href="git://git.gnupg.org/" />
-  <repository type='tarball' name='ftp.gnupg.org' href="ftp://ftp.gnupg.org/" />
   <repository type='tarball' name='ftp.gnu.org' href="ftp://ftp.gnu.org/gnu/"/>
   <repository type="tarball" name="sourceforge" 
               href="http://downloads.sourceforge.net/sourceforge/"/>
@@ -101,13 +100,9 @@
     <branch repo='git.gnupg.org' module="libgpg-error" />
   </autotools>
 
-  <autotools id="libgcrypt" autogen-sh="configure" autogenargs="--disable-asm">
-    <!-- Git version requires fig2dev, an X11 utility, until disable-doc option
-    is available, currently only on master. Master does not work with the
-    version of gnutls used, 2.12.20.
-    <branch repo="git.gnupg.org" module="libgcrypt"/> -->
-    <branch repo="ftp.gnupg.org" version="1.5.4"
-            module="gcrypt/libgcrypt/libgcrypt-1.5.4.tar.bz2"/>
+  <autotools id="libgcrypt" autogen-sh="configure"
+             autogenargs="--disable-asm --disable-doc">
+    <branch repo="git.gnupg.org" module="libgcrypt"/>
     <dependencies>
       <dep package="libgpg-error" />
     </dependencies>

--- a/modulesets-unstable/gtk-osx-unsupported.modules
+++ b/modulesets-unstable/gtk-osx-unsupported.modules
@@ -70,7 +70,7 @@
   <autotools id="libnettle"
 	     autogenargs="--disable-documentation --disable-assembler"
 	     autogen-template="autoreconf -fis &amp;&amp; %(srcdir)s/configure --prefix %(prefix)s  %(autogenargs)s">
-    <!-- gnutls does not support nettle 3.0 yet -->
+    <!-- gnutls 3.3.x does not support nettle 3.0 -->
     <branch repo="lysator" module="nettle/nettle.git"
             tag="nettle_2.7_release_20130424"/>
     <dependencies>

--- a/modulesets-unstable/gtk-osx-unsupported.modules
+++ b/modulesets-unstable/gtk-osx-unsupported.modules
@@ -32,7 +32,9 @@
 	      href="https://git.lysator.liu.se/"/>
   <repository type="tarball" name="icu"
 	      href="http://download.icu-project.org/files/"/>
- 
+  <repository type="git" name="gitorious" href="git://gitorious.org/"/>
+  <repository type="tarball" name="gnutls" href="ftp://ftp.gnutls.org/"/>
+
   <metamodule id="meta-gtk-osx-unsupported">
     <dependencies>
       <dep package="gnome-mime-data"/>
@@ -78,17 +80,16 @@
     </dependencies>
   </autotools>
 
+  <!-- Building from git does not work because they have checked in a bunch of
+  files (build-aux/, po/Makefile.in.in) that they're not supposed to.-->
   <autotools id="gnutls" autogen-sh="configure"
-             autogenargs="--with-libgcrypt --disable-gtk-doc-html">
-    <!-- This is the last version of gnutls that will support libgcrypt;
-    subsequent ones require nettle and gmp. Building from git does not work with
-    Automake >1.12. -->
-    <!--branch repo="git.gnu.org" module="gnutls"/-->
-    <branch repo="ftp.gnu.org" version="2.12.20"
-            module="gnutls/gnutls-2.12.20.tar.bz2"/>
+             autogenargs="--disable-gtk-doc-html">
+    <!--branch repo="gitorious" module="gnutls/gnutls"/-->
+    <branch repo="gnutls" version="3.3.12"
+            module="gcrypt/gnutls/v3.3/gnutls-3.3.12.tar.xz"/>
     <dependencies>
       <dep package="p11-kit"/>
-      <dep package="libgcrypt" />
+      <dep package="libnettle"/>
       <dep package="libtasn1" />
       <dep package="zlib"/>
     </dependencies>

--- a/modulesets-unstable/gtk-osx-unsupported.modules
+++ b/modulesets-unstable/gtk-osx-unsupported.modules
@@ -130,9 +130,8 @@
     </dependencies>
   </autotools>
 
-  <!-- 2.42 requires gnutls 3.0 -->
   <autotools id="glib-networking" autogenargs="--without-ca-certificates set_more_warnings=no">
-    <branch revision="glib-2-40"/>
+    <branch/>
     <dependencies>
       <dep package="gnutls"/>
     </dependencies>

--- a/modulesets-unstable/gtk-osx-unsupported.modules
+++ b/modulesets-unstable/gtk-osx-unsupported.modules
@@ -115,8 +115,8 @@
   <autotools id="libtasn1" supports-non-srcdir-builds="no" >
     <!-- Git repository is missing files required to build libtasn1
     <branch repo="git.gnu.org" /> -->
-    <branch repo="ftp.gnu.org" version="2.14"
-            module="libtasn1/libtasn1-2.14.tar.gz"/>
+    <branch repo="ftp.gnu.org" version="4.2"
+            module="libtasn1/libtasn1-4.2.tar.gz"/>
   </autotools>
 
   <autotools id="libgnome-keyring" autogenargs="--disable-pam --without-root-certs">

--- a/modulesets/gtk-osx-unsupported.modules
+++ b/modulesets/gtk-osx-unsupported.modules
@@ -22,6 +22,8 @@
               href="http://www.webkitgtk.org/releases/"/>
   <repository type='tarball' name='icu'
 	      href='http://download.icu-project.org/files/'/>
+  <repository type="git" name="freedesktop"
+              href="git://anongit.freedesktop.org"/>
 
   <metamodule id="meta-gtk-osx-unsupported">
     <dependencies>
@@ -64,8 +66,15 @@
 	    module="libpng/zlib-1.2.8.tar.gz"/>
   </autotools>
 
+  <autotools id="p11-kit" autogenargs="--without-trust-paths">
+    <branch repo="freedesktop" module="p11-glue/p11-kit" revision="stable"/>
+    <dependencies>
+      <dep package="libtasn1"/>
+    </dependencies>
+  </autotools>
+
   <autotools id="gnutls" autogen-sh="configure"
-	     autogenargs="--with-libgcrypt --without-p11-kit">
+             autogenargs="--with-libgcrypt">
     <!-- This is the last version of gnutls that will support libgcrypt;
     subsequent ones require nettle and gmp. Building from git does not work with
     Autoamke >1.12.-->
@@ -73,6 +82,7 @@
     <branch repo='ftp.gnu.org' version='2.12.20'
             module="gnutls/gnutls-2.12.20.tar.bz2"/>
     <dependencies>
+      <dep package="p11-kit"/>
       <dep package="libgcrypt" />
       <dep package="libtasn1" />
       <dep package="zlib"/>

--- a/modulesets/gtk-osx-unsupported.modules
+++ b/modulesets/gtk-osx-unsupported.modules
@@ -26,6 +26,8 @@
               href="git://anongit.freedesktop.org"/>
   <repository type="git" name="lysator"
               href="https://git.lysator.liu.se/"/>
+  <repository type="git" name="gitorious" href="git://gitorious.org/"/>
+  <repository type="tarball" name="gnutls" href="ftp://ftp.gnutls.org/"/>
 
   <metamodule id="meta-gtk-osx-unsupported">
     <dependencies>
@@ -88,17 +90,16 @@
     </dependencies>
   </autotools>
 
+  <!-- Building from git does not work because they have checked in a bunch of
+  files (build-aux/, po/Makefile.in.in) that they're not supposed to.-->
   <autotools id="gnutls" autogen-sh="configure"
-             autogenargs="--with-libgcrypt">
-    <!-- This is the last version of gnutls that will support libgcrypt;
-    subsequent ones require nettle and gmp. Building from git does not work with
-    Autoamke >1.12.-->
-    <!--branch repo='git.gnu.org' revision='gnutls_2_12_20'/-->
-    <branch repo='ftp.gnu.org' version='2.12.20'
-            module="gnutls/gnutls-2.12.20.tar.bz2"/>
+             autogenargs="--disable-gtk-doc-html">
+    <!--branch repo="gitorious" module="gnutls/gnutls"/-->
+    <branch repo="gnutls" version="3.3.12"
+            module="gcrypt/gnutls/v3.3/gnutls-3.3.12.tar.xz"/>
     <dependencies>
       <dep package="p11-kit"/>
-      <dep package="libgcrypt" />
+      <dep package="libnettle"/>
       <dep package="libtasn1" />
       <dep package="zlib"/>
     </dependencies>

--- a/modulesets/gtk-osx-unsupported.modules
+++ b/modulesets/gtk-osx-unsupported.modules
@@ -24,6 +24,8 @@
 	      href='http://download.icu-project.org/files/'/>
   <repository type="git" name="freedesktop"
               href="git://anongit.freedesktop.org"/>
+  <repository type="git" name="lysator"
+              href="https://git.lysator.liu.se/"/>
 
   <metamodule id="meta-gtk-osx-unsupported">
     <dependencies>
@@ -70,6 +72,19 @@
     <branch repo="freedesktop" module="p11-glue/p11-kit" revision="stable"/>
     <dependencies>
       <dep package="libtasn1"/>
+    </dependencies>
+  </autotools>
+
+  <!-- Rudely demands TeX to build documentation -->
+  <!-- Assembler files are missing md5-compress.asm for x86_64 -->
+  <autotools id="libnettle"
+       autogenargs="--disable-documentation --disable-assembler"
+       autogen-template="autoreconf -fis &amp;&amp; %(srcdir)s/configure --prefix %(prefix)s  %(autogenargs)s">
+    <!-- gnutls 3.3.x does not support nettle 3.0 -->
+    <branch repo="lysator" module="nettle/nettle.git"
+            tag="nettle_2.7_release_20130424"/>
+    <dependencies>
+      <dep package="gmp"/>
     </dependencies>
   </autotools>
 

--- a/modulesets/gtk-osx-unsupported.modules
+++ b/modulesets/gtk-osx-unsupported.modules
@@ -155,11 +155,11 @@
 
   <autotools id="libgcrypt" autogen-sh="configure" autogenargs="--disable-asm">
     <!-- Git version requires fig2dev, an X11 utility, until disable-doc option
-    is available, currently only on master. Master does not work with the
-    version of gnutls used, 2.12.20.
-    <branch repo="git.gnupg.org" tag="libgcrypt-1.5.4" module="libgcrypt"/> -->
-    <branch repo="ftp.gnupg.org" version="1.5.4"
-            module="gcrypt/libgcrypt/libgcrypt-1.5.4.tar.bz2"/>
+    is available, currently only on master.
+    <branch repo="git.gnupg.org" revision="LIBGCRYPT_1_6_BRANCH"
+            module="libgcrypt"/> -->
+    <branch repo="ftp.gnupg.org" version="1.6.2"
+            module="gcrypt/libgcrypt/libgcrypt-1.6.2.tar.bz2"/>
     <dependencies>
       <dep package="libgpg-error" />
     </dependencies>

--- a/modulesets/gtk-osx-unsupported.modules
+++ b/modulesets/gtk-osx-unsupported.modules
@@ -152,9 +152,9 @@
 
   <autotools id="libtasn1" supports-non-srcdir-builds="no" >
     <!-- Git repository is missing files required to build libtasn1
-    <branch repo="git.gnu.org" tag="libtasn1_2_14"  module="libtasn1"/> -->
-    <branch repo="ftp.gnu.org" version='2.14'
-	    module="libtasn1/libtasn1-2.14.tar.gz"/>
+    <branch repo="git.gnu.org" tag="libtasn1_4_2"  module="libtasn1"/> -->
+    <branch repo="ftp.gnu.org" version="4.2"
+            module="libtasn1/libtasn1-4.2.tar.gz"/>
   </autotools>
 
   <autotools id='icu' autogen-sh='source/configure'

--- a/modulesets/gtk-osx-unsupported.modules
+++ b/modulesets/gtk-osx-unsupported.modules
@@ -122,10 +122,9 @@
     </dependencies>
   </autotools>
 
-  <!-- 2.42 requires gnutls 3.0 -->
   <autotools id="glib-networking"
 	     autogenargs="--without-ca-certificates set_more_warnings=no">
-    <branch revision="glib-2-40"/>
+    <branch revision="glib-2-42"/>
     <dependencies>
       <dep package="gnutls"/>
     </dependencies>


### PR DESCRIPTION
Thus upgrades glib-networking and libgcrypt, which were held back by the version of gnutls, which was held back by lack of libnettle with gmp support.