### PR TITLE
WebKit 2.4.x

### DIFF
--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -126,13 +126,14 @@
   </autotools>
 
   <autotools id="harfbuzz" autogen-sh="configure"
-             autogenargs="--with-coretext --with-freetype">
+             autogenargs="--with-coretext --with-freetype --with-icu">
     <branch repo="harfbuzz" module="harfbuzz-0.9.35.tar.bz2" version="0.9.35">
        <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/harfbuzz-kCTTypesetterOptionForcedEmbeddingLevel-Leopard.patch" strip="1"/>
     </branch>
     <dependencies>
       <dep package="freetype-no-harfbuzz"/>
       <dep package="glib"/>
+      <dep package="icu"/>
     </dependencies>
   </autotools>
 

--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -25,6 +25,8 @@
   <repository type="tarball" name="cups"
 	      href="http://ftp.easysw.com/pub/"/>
   <repository type="tarball" name="itstool" href="http://files.itstool.org/"/>
+  <repository type="tarball" name="icu"
+              href="http://download.icu-project.org/files/"/>
 
   <autotools id='readline' autogen-sh="configure">
     <branch repo="ftp.gnu.org" module="readline/readline-6.3.tar.gz"
@@ -123,6 +125,12 @@
       <dep package="itstool"/>
       <dep package="yelp-tools"/>
     </dependencies>
+  </autotools>
+
+  <autotools id="icu" autogen-sh="source/configure"
+             makeargs='CFLAGS="$CFLAGS -DU_CHARSET_IS_UTF8=1 -DU_USING_ICU_NAMESPACE=0"'>
+    <branch repo="icu" version="54.1" checkoutdir="icu"
+            module="icu4c/54.1/icu4c-54_1-src.tgz"/>
   </autotools>
 
   <autotools id="harfbuzz" autogen-sh="configure"

--- a/modulesets-stable/gtk-osx-unsupported.modules
+++ b/modulesets-stable/gtk-osx-unsupported.modules
@@ -21,6 +21,8 @@
               href="http://curl.haxx.se/download/"/>
   <repository type="tarball" name="webkit.org"
               href="http://www.webkitgtk.org/releases/"/>
+  <repository type="tarball" name="webm"
+              href="http://downloads.webmproject.org/releases/"/>
 
   <metamodule id="meta-gtk-osx-unsupported">
     <dependencies>
@@ -152,6 +154,10 @@
    <!-- 10.5 has 7.16.3, which is too old for some things. Otherwise can be skipped. -->
   <autotools id="libcurl" autogen-sh="configure">
     <branch repo="curl.haxx.se" module="curl-7.28.0.tar.bz2" version="7.28.0" />
+  </autotools>
+
+  <autotools id="libwebp" autogen-sh="configure">
+    <branch repo="webm" module="webp/libwebp-0.4.2.tar.gz" version="0.4.2"/>
   </autotools>
 
   <!-- This is WebKitGTK 1.x, for GTK 2.x.

--- a/modulesets-stable/gtk-osx-unsupported.modules
+++ b/modulesets-stable/gtk-osx-unsupported.modules
@@ -188,6 +188,7 @@
     </dependencies>
     <after>
       <dep package="meta-gtk-osx-core"/>
+      <dep package="meta-gstreamer-1.0"/>
     </after>
   </autotools>
 </moduleset>

--- a/modulesets-stable/gtk-osx-unsupported.modules
+++ b/modulesets-stable/gtk-osx-unsupported.modules
@@ -21,8 +21,6 @@
               href="http://curl.haxx.se/download/"/>
   <repository type="tarball" name="webkit.org"
               href="http://www.webkitgtk.org/releases/"/>
-  <repository type='tarball' name='icu'
-	      href='http://download.icu-project.org/files/'/>
 
   <metamodule id="meta-gtk-osx-unsupported">
     <dependencies>
@@ -185,11 +183,5 @@
     <after>
       <dep package="meta-gtk-osx-core"/>
     </after>
-  </autotools>
-
-  <autotools id='icu' autogen-sh='source/configure'
-	     makeargs='CFLAGS="$CFLAGS -DU_CHARSET_IS_UTF8=1 -DU_USING_ICU_NAMESPACE=0"'>
-    <branch repo='icu' version='54.1' checkoutdir='icu'
-            module='icu4c/54.1/icu4c-54_1-src.tgz'/>
   </autotools>
 </moduleset>

--- a/modulesets-stable/gtk-osx-unsupported.modules
+++ b/modulesets-stable/gtk-osx-unsupported.modules
@@ -191,4 +191,39 @@
       <dep package="meta-gstreamer-1.0"/>
     </after>
   </autotools>
+
+  <!-- This is WebKitGTK 2.4.x, the last version that had the WebKit1 API.
+    disable-webkit2: Requires both GTK2 and 3. Currently not supported.
+    disable-credential-storage: Requires libsecret. No module for this yet.
+    disable-geolocation: Requires geoclue 1 or 2. No module for this yet.
+    disable-video, disable-web-audio: Requires gstreamer. If you want video and
+      audio, add this to your .jhbuildrc:
+      append_autogenargs('WebKit', '&#45;-enable-video')
+      append_autogenargs('WebKit', '&#45;-enable-web-audio')
+    -j1: Workaround for https://bugs.webkit.org/show_bug.cgi?id=140171
+  -->
+  <autotools id="webkit1gtk3" autogen-sh="autoreconf" makeargs="-j1"
+             autogenargs="--enable-quartz-target --with-gtk=3.0 --disable-webkit2 --disable-credential-storage --disable-geolocation --disable-video --disable-web-audio CXXFLAGS='-std=gnu++11'">
+    <branch repo="webkit.org" module="webkitgtk-2.4.8.tar.xz" version="2.4.8">
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-126324-clang-check.patch"
+             strip="1"/>
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-140167-disable-netscape-api.patch"
+             strip="1"/>
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-133293-cfi-clang-failure.patch"
+             strip="1"/>
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-126433-check-platform-gtk.patch"
+             strip="1"/>
+    </branch>
+    <dependencies>
+      <dep package="libwebp"/>
+      <dep package="enchant"/>
+      <dep package="icu"/>
+      <dep package="libsoup"/>
+      <dep package="meta-gtk-osx-freetype"/>
+    </dependencies>
+    <after>
+      <dep package="meta-gtk-osx-gtk3"/>
+      <dep package="meta-gstreamer-1.0"/>
+    </after>
+  </autotools>
 </moduleset>

--- a/modulesets-unstable/gtk-osx-bootstrap.modules
+++ b/modulesets-unstable/gtk-osx-bootstrap.modules
@@ -128,12 +128,13 @@
   </autotools>
 
  
-  <autotools id="harfbuzz" autogenargs="--with-coretext">
+  <autotools id="harfbuzz" autogenargs="--with-coretext --with-icu">
     <branch repo="freedesktop" module="harfbuzz"/>
     <dependencies>
       <dep package="freetype-no-harfbuzz"/>
       <dep package="ragel"/>
       <dep package="glib"/>
+      <dep package="icu"/>
     </dependencies>
   </autotools>
 

--- a/modulesets-unstable/gtk-osx-bootstrap.modules
+++ b/modulesets-unstable/gtk-osx-bootstrap.modules
@@ -25,6 +25,8 @@
   <repository type="tarball" name="cups"
 	      href="http://ftp.easysw.com/pub/"/>
   <repository type="git" name="gitorious" href="https://gitorious.org/"/>
+  <repository type="tarball" name="icu"
+              href="http://download.icu-project.org/files/"/>
 
   <autotools id='readline' autogen-sh="configure">
     <branch repo="ftp.gnu.org" module="readline/readline-6.3.tar.gz"
@@ -127,7 +129,12 @@
     </dependencies>
   </autotools>
 
- 
+  <autotools id="icu" autogen-sh="source/configure"
+             makeargs='CFLAGS="$CFLAGS -DU_CHARSET_IS_UTF8=1 -DU_USING_ICU_NAMESPACE=0"'>
+    <branch repo="icu" version="54.1" checkoutdir="icu"
+            module="icu4c/54.1/icu4c-54_1-src.tgz"/>
+  </autotools>
+
   <autotools id="harfbuzz" autogenargs="--with-coretext --with-icu">
     <branch repo="freedesktop" module="harfbuzz"/>
     <dependencies>

--- a/modulesets-unstable/gtk-osx-unsupported.modules
+++ b/modulesets-unstable/gtk-osx-unsupported.modules
@@ -206,6 +206,41 @@
     </after>
   </autotools>
 
+  <!-- This is WebKitGTK 2.4.x, the last version that had the WebKit1 API.
+    disable-webkit2: Requires both GTK2 and 3. Currently not supported.
+    disable-credential-storage: Requires libsecret. No module for this yet.
+    disable-geolocation: Requires geoclue 1 or 2. No module for this yet.
+    disable-video, disable-web-audio: Requires gstreamer. If you want video and
+      audio, add this to your .jhbuildrc:
+      append_autogenargs('WebKit', '&#45;-enable-video')
+      append_autogenargs('WebKit', '&#45;-enable-web-audio')
+    -j1: Workaround for https://bugs.webkit.org/show_bug.cgi?id=140171
+  -->
+  <autotools id="webkit1gtk3" autogen-sh="autoreconf" makeargs="-j1"
+             autogenargs="--enable-quartz-target --with-gtk=3.0 --disable-webkit2 --disable-credential-storage --disable-geolocation --disable-video --disable-web-audio CXXFLAGS='-std=gnu++11'">
+    <branch repo="webkit.org" module="webkitgtk-2.4.8.tar.xz" version="2.4.8">
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-126324-clang-check.patch"
+             strip="1"/>
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-140167-disable-netscape-api.patch"
+             strip="1"/>
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-133293-cfi-clang-failure.patch"
+             strip="1"/>
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-126433-check-platform-gtk.patch"
+             strip="1"/>
+    </branch>
+    <dependencies>
+      <dep package="libwebp"/>
+      <dep package="enchant"/>
+      <dep package="icu"/>
+      <dep package="libsoup"/>
+      <dep package="meta-gtk-osx-freetype"/>
+    </dependencies>
+    <after>
+      <dep package="meta-gtk-osx-gtk3"/>
+      <dep package="meta-gstreamer-1.0"/>
+    </after>
+  </autotools>
+
   <autotools id="WebKit-git"
 	     autogenargs="--enable-quartz-target --disable-x11-target --disable-video --with-font-backend=pango --with-gtk=2.0 --disable-geolocation --disable-webkit2 --disable-credential-storage --disable-svg-fonts --disable-web-audio --disable-fast-malloc --disable-gtk-doc-html">
     <!--branch repo="svn.webkit.org" module="webkit/trunk" checkoutdir="WebKit-svn"/-->

--- a/modulesets-unstable/gtk-osx-unsupported.modules
+++ b/modulesets-unstable/gtk-osx-unsupported.modules
@@ -202,6 +202,7 @@
     </dependencies>
     <after>
       <dep package="meta-gtk-osx-core"/>
+      <dep package="meta-gstreamer-1.0"/>
     </after>
   </autotools>
 

--- a/modulesets-unstable/gtk-osx-unsupported.modules
+++ b/modulesets-unstable/gtk-osx-unsupported.modules
@@ -30,9 +30,7 @@
 	      href="git://anongit.freedesktop.org"/>
   <repository type="git" name="lysator"
 	      href="https://git.lysator.liu.se/"/>
-  <repository type="tarball" name="icu"
-	      href="http://download.icu-project.org/files/"/>
- 
+
   <metamodule id="meta-gtk-osx-unsupported">
     <dependencies>
       <dep package="gnome-mime-data"/>
@@ -169,12 +167,6 @@
     <dependencies>
     </dependencies>
   </cmake>
-
-  <autotools id='icu' autogen-sh='source/configure'
-	     makeargs='CFLAGS="$CFLAGS -DU_CHARSET_IS_UTF8=1 -DU_USING_ICU_NAMESPACE=0"'>
-    <branch repo='icu' version='54.1' checkoutdir='icu'
-            module='icu4c/54.1/icu4c-54_1-src.tgz'/>
-  </autotools>
 
   <!-- This is WebKitGTK 1.x, for GTK 2.x.
     disable-geolocation: Requires geoclue. No module for this yet.

--- a/modulesets-unstable/gtk-osx-unsupported.modules
+++ b/modulesets-unstable/gtk-osx-unsupported.modules
@@ -30,6 +30,8 @@
 	      href="git://anongit.freedesktop.org"/>
   <repository type="git" name="lysator"
 	      href="https://git.lysator.liu.se/"/>
+  <repository type="git" name="chromium"
+              href="https://chromium.googlesource.com/"/>
 
   <metamodule id="meta-gtk-osx-unsupported">
     <dependencies>
@@ -167,6 +169,10 @@
     <dependencies>
     </dependencies>
   </cmake>
+
+  <autotools id="libwebp">
+    <branch repo="chromium" module="webm/libwebp"/>
+  </autotools>
 
   <!-- This is WebKitGTK 1.x, for GTK 2.x.
     disable-geolocation: Requires geoclue. No module for this yet.

--- a/modulesets/gtk-osx-bootstrap.modules
+++ b/modulesets/gtk-osx-bootstrap.modules
@@ -121,12 +121,14 @@
     </dependencies>
   </autotools>
 
-  <autotools id="harfbuzz" autogenargs="--with-coretext --with-freetype">
+  <autotools id="harfbuzz"
+             autogenargs="--with-coretext --with-freetype --with-icu">
     <branch repo="freedesktop" tag="0.9.35"/>
     <dependencies>
       <dep package="freetype-no-harfbuzz"/>
       <dep package="ragel"/>
       <dep package="glib"/>
+      <dep package="icu"/>
     </dependencies>
   </autotools>
 

--- a/modulesets/gtk-osx-bootstrap.modules
+++ b/modulesets/gtk-osx-bootstrap.modules
@@ -25,6 +25,8 @@
   <repository type="tarball" name="cups"
 	      href="http://ftp.easysw.com/pub/"/>
   <repository type="git" name="gitorious" href="https://gitorious.org/"/>
+  <repository type="tarball" name="icu"
+              href="http://download.icu-project.org/files/"/>
 
   <autotools id='readline' autogen-sh="configure">
     <branch repo="ftp.gnu.org" module="readline/readline-6.3.tar.gz"
@@ -119,6 +121,12 @@
       <dep package="itstool"/>
       <dep package="yelp-tools"/>
     </dependencies>
+  </autotools>
+
+  <autotools id="icu" autogen-sh="source/configure"
+             makeargs='CFLAGS="$CFLAGS -DU_CHARSET_IS_UTF8=1 -DU_USING_ICU_NAMESPACE=0"'>
+    <branch repo="icu" version="54.1" checkoutdir="icu"
+            module="icu4c/54.1/icu4c-54_1-src.tgz"/>
   </autotools>
 
   <autotools id="harfbuzz"

--- a/modulesets/gtk-osx-unsupported.modules
+++ b/modulesets/gtk-osx-unsupported.modules
@@ -20,8 +20,6 @@
               tags-template="tags/%(tag)s"/>
   <repository type="tarball" name="webkit.org"
               href="http://www.webkitgtk.org/releases/"/>
-  <repository type='tarball' name='icu'
-	      href='http://download.icu-project.org/files/'/>
 
   <metamodule id="meta-gtk-osx-unsupported">
     <dependencies>
@@ -145,12 +143,6 @@
     <branch repo="git.gnu.org" tag="libtasn1_2_14"  module="libtasn1"/> -->
     <branch repo="ftp.gnu.org" version='2.14'
 	    module="libtasn1/libtasn1-2.14.tar.gz"/>
-  </autotools>
-
-  <autotools id='icu' autogen-sh='source/configure'
-	     makeargs='CFLAGS="$CFLAGS -DU_CHARSET_IS_UTF8=1 -DU_USING_ICU_NAMESPACE=0"'>
-    <branch repo='icu' version='54.1' checkoutdir='icu'
-            module='icu4c/54.1/icu4c-54_1-src.tgz'/>
   </autotools>
 
   <!-- This is WebKitGTK 1.x, for GTK 2.x.

--- a/modulesets/gtk-osx-unsupported.modules
+++ b/modulesets/gtk-osx-unsupported.modules
@@ -18,6 +18,8 @@
   <repository type='svn' name='libproxy.google.com'
               href='http://libproxy.googlecode.com/svn/'
               tags-template="tags/%(tag)s"/>
+  <repository type="git" name="chromium"
+              href="https://chromium.googlesource.com/"/>
   <repository type="tarball" name="webkit.org"
               href="http://www.webkitgtk.org/releases/"/>
 
@@ -143,6 +145,10 @@
     <branch repo="git.gnu.org" tag="libtasn1_2_14"  module="libtasn1"/> -->
     <branch repo="ftp.gnu.org" version='2.14'
 	    module="libtasn1/libtasn1-2.14.tar.gz"/>
+  </autotools>
+
+  <autotools id="libwebp">
+    <branch repo="chromium" module="webm/libwebp" revision="0.4.2"/>
   </autotools>
 
   <!-- This is WebKitGTK 1.x, for GTK 2.x.

--- a/modulesets/gtk-osx-unsupported.modules
+++ b/modulesets/gtk-osx-unsupported.modules
@@ -179,6 +179,7 @@
     </dependencies>
     <after>
       <dep package="meta-gtk-osx-core"/>
+      <dep package="meta-gstreamer-1.0"/>
     </after>
   </autotools>
 </moduleset>

--- a/modulesets/gtk-osx-unsupported.modules
+++ b/modulesets/gtk-osx-unsupported.modules
@@ -182,4 +182,39 @@
       <dep package="meta-gstreamer-1.0"/>
     </after>
   </autotools>
+
+  <!-- This is WebKitGTK 2.4.x, the last version that had the WebKit1 API.
+    disable-webkit2: Requires both GTK2 and 3. Currently not supported.
+    disable-credential-storage: Requires libsecret. No module for this yet.
+    disable-geolocation: Requires geoclue 1 or 2. No module for this yet.
+    disable-video, disable-web-audio: Requires gstreamer. If you want video and
+      audio, add this to your .jhbuildrc:
+      append_autogenargs('WebKit', '&#45;-enable-video')
+      append_autogenargs('WebKit', '&#45;-enable-web-audio')
+    -j1: Workaround for https://bugs.webkit.org/show_bug.cgi?id=140171
+  -->
+  <autotools id="webkit1gtk3" autogen-sh="autoreconf" makeargs="-j1"
+             autogenargs="--enable-quartz-target --with-gtk=3.0 --disable-webkit2 --disable-credential-storage --disable-geolocation --disable-video --disable-web-audio CXXFLAGS='-std=gnu++11'">
+    <branch repo="webkit.org" module="webkitgtk-2.4.8.tar.xz" version="2.4.8">
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-126324-clang-check.patch"
+             strip="1"/>
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-140167-disable-netscape-api.patch"
+             strip="1"/>
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-133293-cfi-clang-failure.patch"
+             strip="1"/>
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/webkit-126433-check-platform-gtk.patch"
+             strip="1"/>
+    </branch>
+    <dependencies>
+      <dep package="libwebp"/>
+      <dep package="enchant"/>
+      <dep package="icu"/>
+      <dep package="libsoup"/>
+      <dep package="meta-gtk-osx-freetype"/>
+    </dependencies>
+    <after>
+      <dep package="meta-gtk-osx-gtk3"/>
+      <dep package="meta-gstreamer-1.0"/>
+    </after>
+  </autotools>
 </moduleset>

--- a/patches/patch status
+++ b/patches/patch status
@@ -39,6 +39,17 @@ Webkit:		webkit-1.10-no-x11.patch
 			See also https://bugs.webkit.org/show_bug.cgi?id=58737
 		webkit-1.10-pango-includes.patch
 
+webkit1gtk:	webkit-126324-clang-check.patch
+			https://bugs.webkit.org/show_bug.cgi?id=126324
+		webkit-140167-disable-netscape-api.patch
+			There's no configure option to disable this. Work around by
+			modifying the variable directly.
+			https://bugs.webkit.org/show_bug.cgi?id=140167
+		webkit-133293-cfi-clang-failure.patch
+			Workaround for https://bugs.webkit.org/show_bug.cgi?id=133293
+		webkit-126433-check-platform-gtk.patch
+			https://bugs.webkit.org/show_bug.cgi?id=126433
+
 GConf:		GConf-characters.patch Bug 161209. Unlikely ever to be fixed.
 
 Glade:		Glade-3-8-Bug-663492-Update-Mac-integration-bindings-to-.patch

--- a/patches/webkit-126324-clang-check.patch
+++ b/patches/webkit-126324-clang-check.patch
@@ -1,0 +1,33 @@
+diff --git a/Source/autotools/CheckSystemAndBasicDependencies.m4 b/Source/autotools/CheckSystemAndBasicDependencies.m4
+--- a/Source/autotools/CheckSystemAndBasicDependencies.m4   (revision 174258)
++++ b/Source/autotools/CheckSystemAndBasicDependencies.m4   (working copy)
+@@ -87,12 +87,12 @@
+ c_compiler="unknown"
+ AC_LANG_PUSH([C])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+-#if !(defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 7)
++#if !(defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && (__GNUC__ >= 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7)))
+ #error Not a supported GCC compiler
+ #endif
+ ])], [c_compiler="gcc"], [])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+-#if !(defined(__clang__) && __clang_major__ >= 3 && __clang_minor__ >= 3)
++#if !(defined(__clang__) && (__apple_build_version__ >= 4250024 || (!defined(__apple_build_version__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 3)))))
+ #error Not a supported Clang compiler
+ #endif
+ ])], [c_compiler="clang"], [])
+@@ -106,12 +106,12 @@
+ cxx_compiler="unknown"
+ AC_LANG_PUSH([C++])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+-#if !(defined(__GNUG__) && defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && __GNUC__ >= 4 && __GNUC_MINOR__ >= 7)
++#if !(defined(__GNUG__) && defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && (__GNUC__ >= 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7)))
+ #error Not a supported G++ compiler
+ #endif
+ ])], [cxx_compiler="g++"], [])
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+-#if !(defined(__clang__) && __clang_major__ >= 3 && __clang_minor__ >= 3)
++#if !(defined(__clang__) && (__apple_build_version__ >= 4250024 || (!defined(__apple_build_version__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 3)))))
+ #error Not a supported Clang++ compiler
+ #endif
+ ])], [cxx_compiler="clang++"], [])

--- a/patches/webkit-126433-check-platform-gtk.patch
+++ b/patches/webkit-126433-check-platform-gtk.patch
@@ -1,0 +1,16 @@
+Index: Source/JavaScriptCore/API/WebKitAvailability.h
+===================================================================
+diff --git a/JavaScriptCore/API/WebKitAvailability.h b/Source/JavaScriptCore/API/WebKitAvailability.h
+--- a/Source/JavaScriptCore/API/WebKitAvailability.h	(revision 174258)
++++ b/Source/JavaScriptCore/API/WebKitAvailability.h	(working copy)
+@@ -26,7 +26,9 @@
+ #ifndef __WebKitAvailability__
+ #define __WebKitAvailability__
+ 
+-#ifdef __APPLE__
++#include <wtf/Platform.h>
++
++#if defined(__APPLE__) && !PLATFORM(GTK)
+ #include <AvailabilityMacros.h>
+ #include <CoreFoundation/CoreFoundation.h>
+ #else

--- a/patches/webkit-133293-cfi-clang-failure.patch
+++ b/patches/webkit-133293-cfi-clang-failure.patch
@@ -1,0 +1,21 @@
+diff --git a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp   (revision 174258)
++++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp   (working copy)
+@@ -522,7 +522,7 @@
+ //
+ 
+ // These are for building an interpreter from generated assembly code:
+-#if CPU(X86_64) && COMPILER(CLANG)
++#if 0
+ #define OFFLINE_ASM_BEGIN   asm ( \
+     ".cfi_startproc\n"
+ 
+@@ -545,7 +545,7 @@
+     ".thumb\n"                                   \
+     ".thumb_func " THUMB_FUNC_PARAM(label) "\n"  \
+     SYMBOL_STRING(label) ":\n"
+-#elif CPU(X86_64) && COMPILER(CLANG)
++#elif 0
+ #define OFFLINE_ASM_GLOBAL_LABEL(label)         \
+     ".text\n"                                   \
+     ".globl " SYMBOL_STRING(label) "\n"         \

--- a/patches/webkit-140167-disable-netscape-api.patch
+++ b/patches/webkit-140167-disable-netscape-api.patch
@@ -1,0 +1,12 @@
+diff --git a/Source/autotools/SetupWebKitFeatures.m4 b/Source/autotools/SetupWebKitFeatures.m4
+--- a/Source/autotools/SetupWebKitFeatures.m4   (revision 174258)
++++ b/Source/autotools/SetupWebKitFeatures.m4   (working copy)
+@@ -146,7 +146,7 @@
+     ENABLE_MHTML=1 \
+     ENABLE_MOUSE_CURSOR_SCALE=0 \
+     ENABLE_NAVIGATOR_CONTENT_UTILS=0 \
+-    ENABLE_NETSCAPE_PLUGIN_API=1 \
++    ENABLE_NETSCAPE_PLUGIN_API=0 \
+     ENABLE_NETWORK_INFO=0 \
+     ENABLE_NOTIFICATIONS=0 \
+     ENABLE_ORIENTATION_EVENTS=0 \


### PR DESCRIPTION
Here's WebKit 2.4.x, built for GTK 3, named "webkit1gtk3" as discussed on the gtk-osx mailing list.

WebKit 2.6, or "webkit2gtk3" in another pull request to follow, but I'm waiting for responses on some upstream bugs before I can get that to work properly.