### PR TITLE
Bootstrap updates

### DIFF
--- a/jhbuildrc-gtk-osx-custom-example
+++ b/jhbuildrc-gtk-osx-custom-example
@@ -138,7 +138,7 @@ setup_sdk(target=_target, sdk_version="native", architectures=[_default_arch])
 
 # Modify the arguments passed to configure:
 #
-# autogenargs["libglade"] = "--enable-static"
+# module_autogenargs["libglade"] = "--enable-static"
 #
 # or simply  add to them:
 #

--- a/modulesets-stable/bootstrap.modules
+++ b/modulesets-stable/bootstrap.modules
@@ -105,6 +105,11 @@
             module="automake/automake-1.14.1.tar.xz"/>
   </autotools>
 
+  <autotools id="automake" autogen-sh="configure">
+    <branch repo="ftp.gnu.org" version="1.15"
+            module="automake/automake-1.15.tar.gz"/>
+  </autotools>
+
   <autotools id="pkg-config" autogen-sh="configure"
              autogenargs="--with-internal-glib">
     <branch repo="pkgconfig"
@@ -191,6 +196,7 @@
       <dep package="automake-1.12" />
       <dep package="automake-1.13" />
       <dep package="automake-1.14"/>
+      <dep package="automake"/>
       <dep package="pkg-config" />
       <dep package="bison"/>
       <dep package="flex"/>

--- a/modulesets-stable/bootstrap.modules
+++ b/modulesets-stable/bootstrap.modules
@@ -26,7 +26,7 @@
   </autotools>
 
   <autotools id="xz" autogen-sh="configure">
-    <branch repo="tukaani.org" module="xz/xz-5.0.7.tar.bz2" version="5.0.7"/>
+    <branch repo="tukaani.org" module="xz/xz-5.2.1.tar.bz2" version="5.2.1"/>
   </autotools>
 
   <autotools id="apr">
@@ -52,13 +52,13 @@
   <autotools id="gettext-tools" autogen-sh="configure"
 	     autogenargs="--without-emacs --disable-java --disable-native-java --disable-libasprintf --disable-csharp --with-included-glib">
     <branch repo="ftp.gnu.org" source-subdir="gettext-tools"
-            module="gettext/gettext-0.19.3.tar.xz" version="0.19.3"
-            size="6628460" md5sum="092c3f460553ceb4a638ff81d36434c4"/>
+            module="gettext/gettext-0.19.4.tar.xz" version="0.19.4"/>
   </autotools>
 
+  <!-- cmakes ./configure is picky about invalid flags so we manually set it -->
   <autotools id="cmake" autogen-sh="bootstrap"
-	     autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s %(autogenargs)s">
-    <branch repo="cmake" module="v3.0/cmake-3.0.2.tar.gz" version="3.0.2"/>
+	     autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s">
+    <branch repo="cmake" module="v3.2/cmake-3.2.1.tar.gz" version="3.2.1"/>
   </autotools>
 
   <autotools id="m4" autogen-sh="configure">
@@ -76,7 +76,7 @@
 
   <autotools id="libtool" autogen-sh="configure">
     <branch repo="ftp.gnu.org"
-            module="libtool/libtool-2.4.3.tar.xz" version="2.4.3"/>
+            module="libtool/libtool-2.4.6.tar.gz" version="2.4.6"/>
   </autotools>
 
   <autotools id="automake-1.10" autogen-sh="configure">
@@ -172,9 +172,9 @@
   </autotools>
 
   <autotools id="intltool" autogen-sh="configure">
-    <branch repo="intltool" module="0.50.2/+download/intltool-0.50.2.tar.gz"
-	    version="0.50.2"
-	    hash="md5:23fbd879118253cb99aeac067da5f591"/>
+    <branch repo="intltool" module="0.51.0/+download/intltool-0.51.0.tar.gz"
+	    version="0.51.0"
+	    hash="md5:12e517cac2b57a0121cda351570f1e63"/>
     <dependencies>
       <dep package="gnome-common"/>
       <dep package="perl-xml-parser"/>

--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -186,8 +186,7 @@
   <autotools id="gettext-runtime" autogen-sh="configure"
 	     autogenargs="--without-emacs --disable-java --disable-native-java --disable-libasprintf --disable-csharp">
     <branch repo="ftp.gnu.org" source-subdir="gettext-runtime"
-            module="gettext/gettext-0.19.3.tar.xz" version="0.19.3"
-            size="6628460" md5sum="092c3f460553ceb4a638ff81d36434c4"/>
+            module="gettext/gettext-0.19.4.tar.xz" version="0.19.4"/>
   </autotools>
 
   <metamodule id="meta-gtk-osx-bootstrap">

--- a/modulesets-unstable/gtk-osx-bootstrap.modules
+++ b/modulesets-unstable/gtk-osx-bootstrap.modules
@@ -170,8 +170,7 @@
   <autotools id="gettext-runtime" autogen-sh="configure"
 	     autogenargs="--without-emacs --disable-java --disable-native-java --disable-libasprintf --disable-csharp">
     <branch repo="ftp.gnu.org" source-subdir="gettext-runtime"
-            module="gettext/gettext-0.19.3.tar.gz" version="0.19.3"
-            size="17414357" md5sum="c365029ffc866fc4e485d9e5ca60b260"/>
+            module="gettext/gettext-0.19.4.tar.gz" version="0.19.4"/>
   </autotools>
 
    <metamodule id="meta-gtk-osx-bootstrap">

--- a/modulesets/gtk-osx-bootstrap.modules
+++ b/modulesets/gtk-osx-bootstrap.modules
@@ -165,15 +165,14 @@
   </autotools>
 
   <autotools id="hicolor-icon-theme" autogen-sh="configure">
-    <branch module="hicolor-icon-theme-0.13.tar.gz" repo="icon-theme"
-            version="0.13"/>
+    <branch module="hicolor-icon-theme-0.15.tar.xz" repo="icon-theme"
+            version="0.15"/>
   </autotools>
 
   <autotools id="gettext-runtime" autogen-sh="configure"
 	     autogenargs="--without-emacs --disable-java --disable-native-java --disable-libasprintf --disable-csharp">
     <branch repo="ftp.gnu.org" source-subdir="gettext-runtime"
-            module="gettext/gettext-0.19.3.tar.xz" version="0.19.3"
-            size="6628460" md5sum="092c3f460553ceb4a638ff81d36434c4"/>
+            module="gettext/gettext-0.19.4.tar.xz" version="0.19.4"/>
   </autotools>
 
   <metamodule id="meta-gtk-osx-bootstrap">

--- a/setup-from-git.sh
+++ b/setup-from-git.sh
@@ -24,14 +24,11 @@ if test ! -d $SOURCE; then
     do_exit "The directory $SOURCE does not exist, please create it and try again."
 fi
 
-#JHBUILD_REVISION=`cat $SOURCE/gtk-osx-build/jhbuild-revision 2>/dev/null`
-#if test x"$JHBUILD_REVISION" = x; then
-#    do_exit "Could not find jhbuild revision to use."
-#fi
-#
-#JHBUILD_REVISION_OPTION="-r$JHBUILD_REVISION"
-#
-echo "Checking out jhbuild ($JHBUILD_REVISION) from git..."
+# This will use jhbuild from git master, but note that jhbuild depends on
+# pkg-config. If you use this, you'll either need to have installed pkg-config
+# already with gtk-osx-build, or you'll need to build pkg-config with Homebrew.
+
+echo "Checking out jhbuild from git..."
 if ! test -d $SOURCE/jhbuild; then
     (cd $SOURCE ; git clone git://git.gnome.org/jhbuild )
 else

--- a/setup-from-git.sh
+++ b/setup-from-git.sh
@@ -39,7 +39,8 @@ else
 fi
 
 echo "Installing jhbuild..."
-(cd $SOURCE/jhbuild && make -f Makefile.plain DISABLE_GETTEXT=1 install >/dev/null)
+sed -i.bak -e 's/env python2/env python/' $SOURCE/jhbuild/scripts/jhbuild.in
+(cd $SOURCE/jhbuild && ./autogen.sh >/dev/null && make -f Makefile.plain DISABLE_GETTEXT=1 install >/dev/null)
 
 echo "Installing jhbuild configuration..."
 ln -sfh `pwd`/jhbuildrc-gtk-osx $HOME/.jhbuildrc
@@ -51,6 +52,7 @@ if [ ! -f $HOME/.jhbuildrc-custom ]; then
 fi
 
 echo "Setting up modulesets..."
+ln -sfh `pwd`/modulesets-stable/bootstrap.modules $SOURCE/jhbuild/modulesets/
 cd modulesets
 for f in `ls *modules`; do
     ln -sfh `pwd`/$f $SOURCE/jhbuild/modulesets/


### PR DESCRIPTION
Here are some updates to the setup and bootstrapping part of gtk-osx-build. The setup-from-git.sh script was defunct, but it seems to work with these changes. Also here are some miscellaneous updates to modules in bootstrap.modules, most notably Automake 1.15.