### PR TITLE
Don't link XQuartz version of freetype2

### DIFF
--- a/jhbuildrc-gtk-osx
+++ b/jhbuildrc-gtk-osx
@@ -126,6 +126,14 @@ def environ_prepend(key, value, separator=' '):
         value = value + separator + old_value
     os.environ[key] = value
 
+def environ_remove(key, value, separator=':'):
+    old_value = os.environ.get(key)
+    if old_value is not None:
+        old_value_split = old_value.split(separator)
+        value_split = [x for x in old_value_split if x != value]
+        value = separator.join(value_split)
+    os.environ[key] = value
+
 def parse_custom_argument(key):
     for i, arg in enumerate(sys.argv[:-1]):
         if arg == key:
@@ -405,6 +413,10 @@ def setup_sdk(target, sdk_version, architectures=[_default_arch]):
     # build products. Note that this will generally break
     # cross-compilation, not that it works anyway.
     os.environ['CFLAGS_FOR_BUILD'] = os.environ['CFLAGS']
+
+    # Make sure we don't link against XQuartz whose freetype-config is on PATH
+    # when XQuartz is installed by removing it from PATH    
+    environ_remove('PATH', '/opt/X11/bin')
     return sdkdir
 
 # This is a convenience function for older .jhbuildrc-customs.


### PR DESCRIPTION
As the freetype2 library isn't a dependency of cairo now, it's not
built by jhbuild. As a consequence, when cairo build script doesn't
find it, it looks further in the system and when XQuartz is installed,
it finds /opt/X11/bin/freetype-config and uses the XQuartz version
of the library.

This patch removes /opt/X11/bin from PATH to make sure the
XQuartz version isn't found and that the resulting binaries don't
depend on external libraries.

This fixes

https://bugzilla.gnome.org/show_bug.cgi?id=757861