### PR TITLE
Add hidpi patches for gtk+-3.0

### DIFF
--- a/modulesets-stable/gtk-osx.modules
+++ b/modulesets-stable/gtk-osx.modules
@@ -205,11 +205,14 @@
     <branch module="gtk+/3.14/gtk+-3.14.15.tar.xz" version="3.14.15"
             hash="sha256:3ac87659112ced9e5ee5bd55d055faa881aafd040f26ca40b0d8ba0fa6509c83">
       <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/0001-Bug-707945-GTK2-Quartz-typeahead-find-in-GtkTreeView.patch" strip="1"/>
+      <!-- https://bugzilla.gnome.org/show_bug.cgi?id=740199#c4 -->
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/gtk3-hidpi.patch" strip="1"/>
     </branch>
     <dependencies>
       <dep package="glib"/>
       <dep package="pango"/>
       <dep package="atk"/>
+      <dep package="cairo"/>
       <dep package="gdk-pixbuf"/>
       <dep package="gobject-introspection"/>
     </dependencies>
@@ -222,11 +225,14 @@
              autogenargs="--enable-quartz-backend --enable-quartz-relocation">
     <branch module="gtk+/3.16/gtk+-3.16.7.tar.xz" version="3.16.7"
             hash="sha256:19689d14de54d182fad538153dbff6d41f53841f940aa871585fdea0306c7fba">
+      <!-- https://bugzilla.gnome.org/show_bug.cgi?id=740199#c4 -->
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/gtk3-hidpi.patch" strip="1"/>
     </branch>
     <dependencies>
       <dep package="glib"/>
       <dep package="pango"/>
       <dep package="atk"/>
+      <dep package="cairo"/>
       <dep package="gdk-pixbuf"/>
       <dep package="gobject-introspection"/>
       <dep package="libepoxy"/>
@@ -255,6 +261,8 @@
     <branch module="cairo-1.14.0.tar.xz"  version="1.14.0"
             repo="cairographics"
             hash="sha1:53cf589b983412ea7f78feee2e1ba9cea6e3ebae">
+      <!-- https://bugs.freedesktop.org/show_bug.cgi?id=69796#c4 -->
+      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/cairo-hidpi.patch" strip="1"/>
     </branch>
     <dependencies>
       <dep package="pixman"/>

--- a/patches/cairo-hidpi.patch
+++ b/patches/cairo-hidpi.patch
@@ -1,0 +1,37 @@
+From 8c8b2b518d1a6067b7f203309bd4158de7cb78b9 Mon Sep 17 00:00:00 2001
+From: Brion Vibber <brion@pobox.com>
+Date: Sun, 16 Nov 2014 16:53:13 -0800
+Subject: [PATCH] Provisional fix for cairo scaling on Quartz backend
+
+CGContexts by default apply a device scaling factor, which ends up
+interfering with the device_scale that is set on cairo at higher levels
+of the stack (eg in GDK).
+
+Undoing it here makes behavior more consistent with X11, as long as the
+caller sets the device scale appropriately in cairo.
+
+See:
+* https://www.libreoffice.org/bugzilla/show_bug.cgi?id=69796
+* https://bugzilla.gnome.org/show_bug.cgi?id=740199
+---
+ src/cairo-quartz-surface.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/cairo-quartz-surface.c b/src/cairo-quartz-surface.c
+index 1116ff9..f763668 100644
+--- a/src/cairo-quartz-surface.c
++++ b/src/cairo-quartz-surface.c
+@@ -2266,6 +2266,10 @@ _cairo_quartz_surface_create_internal (CGContextRef cgContext,
+ 	return surface;
+     }
+ 
++    /* Undo the default scaling transform, since we apply our own */
++    CGSize scale = CGContextConvertSizeToDeviceSpace (cgContext, CGSizeMake (1.0, 1.0));
++    CGContextScaleCTM(cgContext, 1.0 / scale.width, 1.0 / scale.height);
++
+     /* Save so we can always get back to a known-good CGContext -- this is
+      * required for proper behaviour of intersect_clip_path(NULL)
+      */
+-- 
+1.9.3 (Apple Git-50)
+

--- a/patches/gtk3-hidpi.patch
+++ b/patches/gtk3-hidpi.patch
@@ -1,0 +1,41 @@
+From 2544b9256318b5f921e6eebb5925bdc8b3419125 Mon Sep 17 00:00:00 2001
+From: Brion Vibber <brion@pobox.com>
+Date: Sun, 16 Nov 2014 15:10:30 -0800
+Subject: [PATCH 3/3] Work in progress fix for low-res GL views on Quartz
+ HiDPI/Retina
+
+gdk_quartz_ref_cairo_surface () wasn't respecting the window's scale
+when creating a surface, whereas the equivalent on other backends was.
+
+This patch fixes GL views, but breaks non-GL ones on Retina display
+by making them double-sized. Not sure where the doubling on that code
+path is yet...
+---
+ gdk/quartz/gdkwindow-quartz.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/gdk/quartz/gdkwindow-quartz.c b/gdk/quartz/gdkwindow-quartz.c
+index 1d39e8f..04539d3 100644
+--- a/gdk/quartz/gdkwindow-quartz.c
++++ b/gdk/quartz/gdkwindow-quartz.c
+@@ -320,10 +320,15 @@ gdk_quartz_ref_cairo_surface (GdkWindow *window)
+ 
+   if (!impl->cairo_surface)
+     {
++      int scale = gdk_window_get_scale_factor (impl->wrapper);
++      if (scale == 0)
++        scale = 1;
++
+       impl->cairo_surface = 
+           gdk_quartz_create_cairo_surface (impl,
+-                                           gdk_window_get_width (impl->wrapper),
+-                                           gdk_window_get_height (impl->wrapper));
++                                           gdk_window_get_width (impl->wrapper) * scale,
++                                           gdk_window_get_height (impl->wrapper) * scale);
++      cairo_surface_set_device_scale (impl->cairo_surface, scale, scale);
+     }
+   else
+     cairo_surface_reference (impl->cairo_surface);
+-- 
+1.9.3 (Apple Git-50)
+


### PR DESCRIPTION
One in gtk+ to use the system provided scaling factor and one
in cairo to disable CGContexts scaling so we can do our own scaling.

This fixes pixelated rendering in all cases where the gtk pixel cache
is used (treeviews..) and where icons are converted to cairo surfaces.

Any remaining pixelation (DnD, menu icons) was fixed in gtk+3.18

This also adds the gtk patch to gtk+-3.14 as the cairo patch alone breaks
drawing on hidpi setups without the gtk+ counterpart.

----------------

I've shipped these patches for a year now with gtk+3.16 and my hidpi fixes which are also included in gtk+3.18: https://git.gnome.org/browse/gtk+/log/?qt=grep&q=quartz.*hidpi

I haven't found the time to look into upstreaming these.. but I guess it would be good to have working hidpi with gtk-osx.