### PR TITLE
Bump gtk to 3.18.9 and glib to 2.46.2

### DIFF
--- a/modulesets-stable/gtk-osx.modules
+++ b/modulesets-stable/gtk-osx.modules
@@ -76,8 +76,8 @@
   </metamodule>
 
   <autotools id="glib" autogen-sh="autoreconf">
-    <branch module="glib/2.44/glib-2.44.1.tar.xz"  version="2.44.1"
-            hash="sha256:8811deacaf8a503d0a9b701777ea079ca6a4277be10e3d730d2112735d5eca07">
+    <branch module="glib/2.46/glib-2.46.2.tar.xz"  version="2.46.2"
+            hash="sha256:5031722e37036719c1a09163cc6cf7c326e4c4f1f1e074b433c156862bd733db">
       <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/0001-Fix-g_get_monotonic_time-on-non-Intel-Darwin.patch" strip="1"/>
       <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/0001-Bug-724590-GSlice-slab_stack-corruption.patch" strip="1"/>
       <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/gio-in-reserved-in-gcc-48.patch" strip="1"/>
@@ -206,8 +206,8 @@
 
   <autotools id="gtk+-3.0" autogen-sh="autogen.sh"
              autogenargs="--enable-quartz-backend --enable-quartz-relocation">
-    <branch module="gtk+/3.16/gtk+-3.16.7.tar.xz" version="3.16.7"
-            hash="sha256:19689d14de54d182fad538153dbff6d41f53841f940aa871585fdea0306c7fba">
+    <branch module="gtk+/3.18/gtk+-3.18.9.tar.xz" version="3.18.9"
+            hash="sha256:783d7f8b00f9b4224cc94d7da885a67598e711c2d6d79c9c873c6b203e83acbd">
       <!-- https://bugzilla.gnome.org/show_bug.cgi?id=763779 -->
       <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/gtk-quartz-fix-pixelated-image-surfaces-in-retina-hidpi-.patch" strip="1"/>
     </branch>


### PR DESCRIPTION
Is it OK to do? The thing is that with the current 3.16.7 I'm running into

https://bugzilla.gnome.org/show_bug.cgi?id=753992

with Geany which causes it to crash every time focus leaves the editor area which makes 3.16.7 unusable. From what I have tried there don't seem to be any problems with gtk 3.18.9. If there's some reason why 3.18 shouldn't be used, I can also backport the patch fixing the bug to 3.16.