### PR TITLE
minor version updates

### DIFF
--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -51,8 +51,10 @@
   </autotools>
 
   <autotools id="libtiff" autogen-sh="configure" autogenargs="--without-x">
-    <branch version="4.0.7" module="libtiff/tiff-4.0.7.tar.gz"
-	    repo="libtiff"/>
+    <branch version="4.0.8" module="libtiff/tiff-4.0.8.tar.gz"
+	    repo="libtiff">
+	<patch file="https://raw.githubusercontent.com/totaam/gtk-osx-build/master/patches/tiff-nohtml.patch" strip="1" />
+    </branch>
     <dependencies>
       <dep package="libjpeg"/>
     </dependencies>

--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -35,8 +35,12 @@
   </autotools>
   
   <autotools id="libpng" autogenargs="--enable-shared" autogen-sh="configure">
-    <branch version="1.6.29" module="libpng/libpng-1.6.29.tar.xz"
+    <branch version="1.6.34" module="libpng/libpng-1.6.34.tar.xz"
+            hash="sha256:2f1e960d92ce3b3abd03d06dfec9637dfbd22febf107a536b44f7a47c60659f6"
             repo="sourceforge"/>
+    <dependencies>
+      <dep package="zlib"/>
+    </dependencies>
   </autotools>
 
   <autotools id="libjpeg" autogen-sh="configure">

--- a/modulesets-stable/gtk-osx-gstreamer.modules
+++ b/modulesets-stable/gtk-osx-gstreamer.modules
@@ -2,7 +2,7 @@
 <!DOCTYPE moduleset SYSTEM "moduleset.dtd">
 <?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
 <moduleset>
-  <repository type="tarball" name="gstreamer"
+  <repository type="tarball" name="gstreamer" default="yes"
               href="http://gstreamer.freedesktop.org/src/"/>
   <repository type="tarball" name="sourceforge"
               href="http://iweb.dl.sf.net/project/"/>

--- a/modulesets-stable/gtk-osx-gstreamer.modules
+++ b/modulesets-stable/gtk-osx-gstreamer.modules
@@ -2,15 +2,13 @@
 <!DOCTYPE moduleset SYSTEM "moduleset.dtd">
 <?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
 <moduleset>
-  <repository type="tarball" name="ftp.gnome.org" default="yes"
-              href="http://ftp.gnome.org/pub/GNOME/sources/"/>
   <repository type="tarball" name="gstreamer"
               href="http://gstreamer.freedesktop.org/src/"/>
   <repository type="tarball" name="sourceforge"
               href="http://iweb.dl.sf.net/project/"/>
 
   <autotools id="liborc" autogen-sh="configure">
-    <branch repo="gstreamer" module="orc/orc-0.4.28.tar.xz" version="0.4.28"
+    <branch module="orc/orc-0.4.28.tar.xz" version="0.4.28"
             hash="sha256:bfcd7c6563b05672386c4eedfc4c0d4a0a12b4b4775b74ec6deb88fc2bcd83ce"/>
   </autotools>
 
@@ -24,8 +22,8 @@
 
   <autotools id="gstreamer" autogenargs="--disable-tests" supports-non-srcdir-builds="no"
     makeargs="ERROR_CFLAGS=" autogen-sh="configure">
-    <branch module="gstreamer/1.10/gstreamer-1.10.5.tar.xz" version="1.10.5"
-            hash="sha256:bc06243600817f637029da29d089d5908d1d266542f68bf6626a10c5f05f1f1d">
+    <branch module="gstreamer/gstreamer-1.12.4.tar.xz" version="1.12.4"
+            hash="sha256:5a8704aa4c2eeb04da192c4a9942f94f860ac1a585de90d9f914bac26a970674">
     </branch>
     <after>
       <dep package="glib"/>
@@ -34,9 +32,9 @@
 
   <autotools id="gst-plugins-base" autogenargs="--disable-tests --disable-x --disable-xvideo" supports-non-srcdir-builds="no"
     makeargs="ERROR_CFLAGS=" autogen-sh="configure">
-    <branch module="gst-plugins-base/1.10/gst-plugins-base-1.10.5.tar.xz"
-            version="1.10.5"
-            hash="sha256:1c401a79bd1e4521c6ef1b66579bddedd9136e164e54792aab4bfcf3485bf9a7"/>
+    <branch module="gst-plugins-base/gst-plugins-base-1.12.4.tar.xz"
+            version="1.12.4"
+            hash="sha256:4c306b03df0212f1b8903784e29bb3493319ba19ebebf13b0c56a17870292282"/>
     <dependencies>
       <dep package="gstreamer"/>
       <dep package="liborc"/>
@@ -47,9 +45,9 @@
 
   <autotools id="gst-plugins-good" autogenargs="--disable-tests --disable-x --disable-xvideo --disable-osx-video" supports-non-srcdir-builds="no"
     makeargs="ERROR_CFLAGS=" autogen-sh="configure">
-    <branch module="gst-plugins-good/1.10/gst-plugins-good-1.10.5.tar.xz"
-            version="1.10.5"
-            hash="sha256:be053f6ed716eeb517cec148cec637cdce571c6e04d5c21409e2876fb76c7639">
+    <branch module="gst-plugins-good/gst-plugins-good-1.12.4.tar.xz"
+            version="1.12.4"
+            hash="sha256:649f49bec60892d47ee6731b92266974c723554da1c6649f21296097715eb957">
     </branch>
     <dependencies>
       <dep package="gstreamer"/>
@@ -60,9 +58,9 @@
   <autotools id="gst-plugins-ugly" autogenargs="--disable-tests"
              supports-non-srcdir-builds="no" makeargs="ERROR_CFLAGS="
              autogen-sh="configure">
-    <branch repo="gstreamer" version="1.10.5"
-            module="gst-plugins-ugly/gst-plugins-ugly-1.10.5.tar.xz"
-            hash="sha256:d6edc046350809c967f5b058c5c2e534d99d1d69fe1b26acd849e87781a7d7fc"/>
+    <branch version="1.12.4"
+            module="gst-plugins-ugly/gst-plugins-ugly-1.12.4.tar.xz"
+            hash="sha256:1c165b8d888ed350acd8e6ac9f6fe06508e6fcc0a3afc6ccc9fbeb30df9be522"/>
     <dependencies>
       <dep package="gstreamer"/>
       <dep package="gst-plugins-base"/>
@@ -72,9 +70,9 @@
   <autotools id="gst-plugins-bad" supports-non-srcdir-builds="no"
              autogenargs="--disable-tests --disable-x --disable-xvid"
              makeargs="ERROR_CFLAGS=" autogen-sh="configure">
-    <branch repo="gstreamer" version="1.10.5"
-            module="gst-plugins-bad/gst-plugins-bad-1.10.5.tar.xz"
-            hash="sha256:c5806040bb83b43be86ce592e6a19c5d83d7776f7d9f434eb4b911c4efff3573"/>
+    <branch version="1.12.4"
+            module="gst-plugins-bad/gst-plugins-bad-1.12.4.tar.xz"
+            hash="sha256:0c7857be16686d5c1ba6e34bd338664d3d4599d32714a8eca5c8a41a101e2d08"/>
     <dependencies>
       <dep package="gstreamer"/>
       <dep package="gst-plugins-base"/>
@@ -88,9 +86,9 @@
   <autotools id="gst-libav" supports-non-srcdir-builds="no"
              autogen-sh="configure"
              autogenargs="--disable-tests --disable-mmx --with-libav-extra-configure='--disable-yasm'">
-     <branch repo="gstreamer" version="1.10.5"
-            module="gst-libav/gst-libav-1.10.5.tar.xz"
-            hash="sha256:e4d2f315f478d47281fbfdfbd590a63d23704ca37911d7142d5992616f4b28d3"/>
+     <branch version="1.12.4"
+            module="gst-libav/gst-libav-1.12.4.tar.xz"
+            hash="sha256:2a56aa5d2d8cd912f2bce17f174713d2c417ca298f1f9c28ee66d4aa1e1d9e62"/>
     <dependencies>
       <dep package="gstreamer"/>
       <dep package="gst-plugins-base"/>

--- a/modulesets-stable/gtk-osx-gstreamer.modules
+++ b/modulesets-stable/gtk-osx-gstreamer.modules
@@ -10,8 +10,8 @@
               href="http://iweb.dl.sf.net/project/"/>
 
   <autotools id="liborc" autogen-sh="configure">
-    <branch repo="gstreamer" module="orc/orc-0.4.26.tar.xz" version="0.4.26"
-            hash="sha256:7d52fa80ef84988359c3434e1eea302d077a08987abdde6905678ebcad4fa649"/>
+    <branch repo="gstreamer" module="orc/orc-0.4.28.tar.xz" version="0.4.28"
+            hash="sha256:bfcd7c6563b05672386c4eedfc4c0d4a0a12b4b4775b74ec6deb88fc2bcd83ce"/>
   </autotools>
 
   <autotools id="faad2" autogen-sh="autoreconf"

--- a/modulesets-stable/gtk-osx-gstreamer.modules
+++ b/modulesets-stable/gtk-osx-gstreamer.modules
@@ -24,8 +24,8 @@
 
   <autotools id="gstreamer" autogenargs="--disable-tests" supports-non-srcdir-builds="no"
     makeargs="ERROR_CFLAGS=" autogen-sh="configure">
-    <branch module="gstreamer/1.10/gstreamer-1.10.4.tar.xz" version="1.10.4"
-            hash="sha256:50c2f5af50a6cc6c0a3f3ed43bdd8b5e2bff00bacfb766d4be139ec06d8b5218">
+    <branch module="gstreamer/gstreamer-1.10.5.tar.xz" version="1.10.5"
+            hash="sha256:bc06243600817f637029da29d089d5908d1d266542f68bf6626a10c5f05f1f1d">
     </branch>
     <after>
       <dep package="glib"/>
@@ -34,9 +34,9 @@
 
   <autotools id="gst-plugins-base" autogenargs="--disable-tests --disable-x --disable-xvideo" supports-non-srcdir-builds="no"
     makeargs="ERROR_CFLAGS=" autogen-sh="configure">
-    <branch module="gst-plugins-base/1.10/gst-plugins-base-1.10.4.tar.xz"
-            version="1.10.4"
-            hash="sha256:f6d245b6b3d4cb733f81ebb021074c525ece83db0c10e932794b339b8d935eb7"/>
+    <branch module="gst-plugins-base/gst-plugins-base-1.10.5.tar.xz"
+            version="1.10.5"
+            hash="sha256:1c401a79bd1e4521c6ef1b66579bddedd9136e164e54792aab4bfcf3485bf9a7"/>
     <dependencies>
       <dep package="gstreamer"/>
       <dep package="liborc"/>
@@ -47,9 +47,10 @@
 
   <autotools id="gst-plugins-good" autogenargs="--disable-tests --disable-x --disable-xvideo --disable-osx-video" supports-non-srcdir-builds="no"
     makeargs="ERROR_CFLAGS=" autogen-sh="configure">
-    <branch module="gst-plugins-good/1.10/gst-plugins-good-1.10.4.tar.xz"
-            version="1.10.4"
-            hash="sha256:8a86c61434a8c44665365bd0b3557a040937d1f44bf69caee4e9ea816ce74d7e"/>
+    <branch module="gst-plugins-good/gst-plugins-good-1.10.5.tar.xz"
+            version="1.10.5"
+            hash="sha256:be053f6ed716eeb517cec148cec637cdce571c6e04d5c21409e2876fb76c7639">
+    </branch>
     <dependencies>
       <dep package="gstreamer"/>
       <dep package="gst-plugins-base"/>
@@ -59,9 +60,9 @@
   <autotools id="gst-plugins-ugly" autogenargs="--disable-tests"
              supports-non-srcdir-builds="no" makeargs="ERROR_CFLAGS="
              autogen-sh="configure">
-    <branch repo="gstreamer" version="1.10.4"
-            module="gst-plugins-ugly/gst-plugins-ugly-1.10.4.tar.xz"
-            hash="sha256:6386c77ca8459cba431ed0b63da780c7062c7cc48055d222024d8eaf198ffa59"/>
+    <branch repo="gstreamer" version="1.10.5"
+            module="gst-plugins-ugly/gst-plugins-ugly-1.10.5.tar.xz"
+            hash="sha256:d6edc046350809c967f5b058c5c2e534d99d1d69fe1b26acd849e87781a7d7fc"/>
     <dependencies>
       <dep package="gstreamer"/>
       <dep package="gst-plugins-base"/>
@@ -71,9 +72,9 @@
   <autotools id="gst-plugins-bad" supports-non-srcdir-builds="no"
              autogenargs="--disable-tests --disable-x --disable-xvid"
              makeargs="ERROR_CFLAGS=" autogen-sh="configure">
-    <branch repo="gstreamer" version="1.10.4"
-            module="gst-plugins-bad/gst-plugins-bad-1.10.4.tar.xz"
-            hash="sha256:23ddae506b3a223b94869a0d3eea3e9a12e847f94d2d0e0b97102ce13ecd6966"/>
+    <branch repo="gstreamer" version="1.10.5"
+            module="gst-plugins-bad/gst-plugins-bad-1.10.5.tar.xz"
+            hash="sha256:c5806040bb83b43be86ce592e6a19c5d83d7776f7d9f434eb4b911c4efff3573"/>
     <dependencies>
       <dep package="gstreamer"/>
       <dep package="gst-plugins-base"/>
@@ -87,9 +88,9 @@
   <autotools id="gst-libav" supports-non-srcdir-builds="no"
              autogen-sh="configure"
              autogenargs="--disable-tests --disable-mmx --with-libav-extra-configure='--disable-yasm'">
-    <branch repo="gstreamer" version="1.10.4"
-            module="gst-libav/gst-libav-1.10.4.tar.xz"
-            hash="sha256:6ca0feca75e3d48315e07f20ec37cf6260ed1e9dde58df355febd5016246268b"/>
+     <branch repo="gstreamer" version="1.10.5"
+            module="gst-libav/gst-libav-1.10.5.tar.xz"
+            hash="sha256:e4d2f315f478d47281fbfdfbd590a63d23704ca37911d7142d5992616f4b28d3"/>
     <dependencies>
       <dep package="gstreamer"/>
       <dep package="gst-plugins-base"/>

--- a/modulesets-stable/gtk-osx-gstreamer.modules
+++ b/modulesets-stable/gtk-osx-gstreamer.modules
@@ -24,7 +24,7 @@
 
   <autotools id="gstreamer" autogenargs="--disable-tests" supports-non-srcdir-builds="no"
     makeargs="ERROR_CFLAGS=" autogen-sh="configure">
-    <branch module="gstreamer/gstreamer-1.10.5.tar.xz" version="1.10.5"
+    <branch module="gstreamer/1.10/gstreamer-1.10.5.tar.xz" version="1.10.5"
             hash="sha256:bc06243600817f637029da29d089d5908d1d266542f68bf6626a10c5f05f1f1d">
     </branch>
     <after>
@@ -34,7 +34,7 @@
 
   <autotools id="gst-plugins-base" autogenargs="--disable-tests --disable-x --disable-xvideo" supports-non-srcdir-builds="no"
     makeargs="ERROR_CFLAGS=" autogen-sh="configure">
-    <branch module="gst-plugins-base/gst-plugins-base-1.10.5.tar.xz"
+    <branch module="gst-plugins-base/1.10/gst-plugins-base-1.10.5.tar.xz"
             version="1.10.5"
             hash="sha256:1c401a79bd1e4521c6ef1b66579bddedd9136e164e54792aab4bfcf3485bf9a7"/>
     <dependencies>
@@ -47,7 +47,7 @@
 
   <autotools id="gst-plugins-good" autogenargs="--disable-tests --disable-x --disable-xvideo --disable-osx-video" supports-non-srcdir-builds="no"
     makeargs="ERROR_CFLAGS=" autogen-sh="configure">
-    <branch module="gst-plugins-good/gst-plugins-good-1.10.5.tar.xz"
+    <branch module="gst-plugins-good/1.10/gst-plugins-good-1.10.5.tar.xz"
             version="1.10.5"
             hash="sha256:be053f6ed716eeb517cec148cec637cdce571c6e04d5c21409e2876fb76c7639">
     </branch>

--- a/modulesets-stable/gtk-osx-network.modules
+++ b/modulesets-stable/gtk-osx-network.modules
@@ -60,8 +60,9 @@
 
   <autotools id="libtasn1" supports-non-srcdir-builds="no"
              autogen-sh="configure">
-    <branch repo="ftp.gnu.org" version="4.10"
-            module="libtasn1/libtasn1-4.10.tar.gz"/>
+    <branch repo="ftp.gnu.org" version="4.12"
+            module="libtasn1/libtasn1-4.12.tar.gz"
+            hash="sha256:6753da2e621257f33f5b051cc114d417e5206a0818fe0b1ecfd6153f70934753" />
   </autotools>
 
   <autotools id="zlib" autogen-sh="configure" skip-autogen="never"

--- a/modulesets-stable/gtk-osx-python.modules
+++ b/modulesets-stable/gtk-osx-python.modules
@@ -75,7 +75,6 @@
     <branch repo="python"
            module="2.7.14/Python-2.7.14.tar.xz" version="2.7.14"
            hash="sha256:71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66">
-      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-test_grammar.py-typo.patch" strip="1"/>
       <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-linkflags.patch" strip="1"/>"/>
     </branch>
     <dependencies>

--- a/modulesets-stable/gtk-osx-python.modules
+++ b/modulesets-stable/gtk-osx-python.modules
@@ -73,7 +73,9 @@
   <autotools id="python" autogenargs="--enable-shared"
 	     autogen-sh="configure" supports-non-srcdir-builds="no">
     <branch repo="python"
-	    module="2.7.13/Python-2.7.13.tar.xz" version="2.7.13">
+           module="2.7.14/Python-2.7.14.tar.xz" version="2.7.14"
+           hash="sha256:71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66">
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-test_grammar.py-typo.patch" strip="1"/>
       <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-linkflags.patch" strip="1"/>"/>
     </branch>
     <dependencies>
@@ -88,7 +90,7 @@
   </autotools>
 
   <autotools id="python3" autogenargs="--enable-shared" autogen-sh="configure">
-    <branch repo="python" module="3.6.1/Python-3.6.1.tar.xz" version="3.6.1">
+    <branch repo="python" module="3.6.4/Python-3.6.4.tar.xz" version="3.6.4">
       <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/Python3.4-stack_size-flag.patch" strip="1"/>
     </branch>
     <dependencies>

--- a/modulesets-unstable/gtk-osx-network.modules
+++ b/modulesets-unstable/gtk-osx-network.modules
@@ -65,8 +65,9 @@
   <autotools id="libtasn1" supports-non-srcdir-builds="no">
     <!-- Git repository is missing files required to build libtasn1
     <branch repo="git.gnu.org" /> -->
-    <branch repo="ftp.gnu.org" version="4.10"
-            module="libtasn1/libtasn1-4.10.tar.gz"/>
+    <branch repo="ftp.gnu.org" version="4.12"
+            module="libtasn1/libtasn1-4.12.tar.gz"
+            hash="sha256:6753da2e621257f33f5b051cc114d417e5206a0818fe0b1ecfd6153f70934753" />
   </autotools>
 
   <autotools id="zlib" autogen-sh="configure" skip-autogen="never"

--- a/modulesets-unstable/gtk-osx-python.modules
+++ b/modulesets-unstable/gtk-osx-python.modules
@@ -57,9 +57,9 @@
   <autotools id="python" autogenargs="--enable-shared" supports-non-srcdir-builds="no"
 	     autogen-sh="configure">
     <branch repo="python"
-	    module="2.7.13/Python-2.7.13.tar.xz" version="2.7.13">
-      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-linkflags.patch" strip="1"/>
-      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python-issue27806_v3.patch" strip="1"/>
+           module="2.7.14/Python-2.7.14.tar.xz" version="2.7.14"
+           hash="sha256:71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66">
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-linkflags.patch" strip="1"/>"/>
     </branch>
     <dependencies>
       <dep package="gettext-runtime"/>
@@ -73,7 +73,7 @@
 
   <autotools id="python3" autogenargs="--enable-shared" autogen-sh="configure">
     <branch repo="python"
-	    module="3.6.1/Python-3.6.1.tar.xz" version="3.6.1">
+	    module="3.6.4/Python-3.6.4.tar.xz" version="3.6.4">
       <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/Python3.4-stack_size-flag.patch" strip="1"/>
     </branch>
     <dependencies>

--- a/modulesets/gtk-osx-network.modules
+++ b/modulesets/gtk-osx-network.modules
@@ -62,8 +62,9 @@
   <autotools id="libtasn1" supports-non-srcdir-builds="no">
     <!-- Git repository is missing files required to build libtasn1
     <branch repo="git.gnu.org" tag="libtasn1_4_4"  module="libtasn1"/> -->
-    <branch repo="ftp.gnu.org" version="4.10"
-            module="libtasn1/libtasn1-4.10.tar.gz"/>
+    <branch repo="ftp.gnu.org" version="4.12"
+            module="libtasn1/libtasn1-4.12.tar.gz"
+            hash="sha256:6753da2e621257f33f5b051cc114d417e5206a0818fe0b1ecfd6153f70934753" />
   </autotools>
 
   <autotools id="zlib" autogen-sh="configure" skip-autogen="never"

--- a/modulesets/gtk-osx-python.modules
+++ b/modulesets/gtk-osx-python.modules
@@ -59,9 +59,9 @@
   <autotools id="python" autogenargs="--enable-shared"
 	     autogen-sh="configure">
     <branch repo="python"
-	    module="2.7.13/Python-2.7.13.tar.xz" version="2.7.13">
-      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-linkflags.patch" strip="1"/>
-      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python-issue27806_v3.patch" strip="1"/>
+	    module="2.7.14/Python-2.7.14.tar.xz" version="2.7.14"
+            hash="sha256:71ffb26e09e78650e424929b2b457b9c912ac216576e6bd9e7d204ed03296a66">
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-linkflags.patch" strip="1"/>"/>
     </branch>
     <dependencies>
       <dep package="gettext-runtime"/>
@@ -74,7 +74,7 @@
   </autotools>
 
   <autotools id="python3" autogenargs="--enable-shared" autogen-sh="configure">
-    <branch repo="python" module="3.6.1/Python-3.6.1.tar.xz" version="3.6.1">
+    <branch repo="python" module="3.6.4/Python-3.6.4.tar.xz" version="3.6.4">
       <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/Python3.4-stack_size-flag.patch" strip="1"/>
     </branch>
     <dependencies>

--- a/patches/glib-2.52-Fallback-to-CFStringGetCSTring-if-CFStringGetC.patch
+++ b/patches/glib-2.52-Fallback-to-CFStringGetCSTring-if-CFStringGetC.patch
@@ -130,9 +130,9 @@ index 3589b12..a0da5f6 100644
  main (int argc, char *argv[])
  {
 @@ -370,6 +397,7 @@ main (int argc, char *argv[])
+   g_test_init (&argc, &argv, NULL);
  
    g_test_add_func ("/contenttype/guess", test_guess);
-   g_test_add_func ("/contenttype/guess_svg_from_data", test_guess_svg_from_data);
 +  g_test_add_func ("/contenttype/mime_from_content", test_mime_from_content);
    g_test_add_func ("/contenttype/unknown", test_unknown);
    g_test_add_func ("/contenttype/subtype", test_subtype);

--- a/patches/tiff-nohtml.patch
+++ b/patches/tiff-nohtml.patch
@@ -1,0 +1,44 @@
+--- a/configure	2017-05-22 01:49:37.000000000 +0700
++++ b/configure	2017-06-12 02:37:01.000000000 +0700
+@@ -20927,7 +20927,7 @@
+ ac_config_headers="$ac_config_headers libtiff/tif_config.h libtiff/tiffconf.h"
+ 
+ 
+-ac_config_files="$ac_config_files Makefile build/Makefile contrib/Makefile contrib/addtiffo/Makefile contrib/dbs/Makefile contrib/dbs/xtiff/Makefile contrib/iptcutil/Makefile contrib/mfs/Makefile contrib/pds/Makefile contrib/ras/Makefile contrib/stream/Makefile contrib/tags/Makefile contrib/win_dib/Makefile html/Makefile html/images/Makefile html/man/Makefile libtiff-4.pc libtiff/Makefile man/Makefile port/Makefile test/Makefile tools/Makefile"
++ac_config_files="$ac_config_files Makefile build/Makefile contrib/Makefile contrib/addtiffo/Makefile contrib/dbs/Makefile contrib/dbs/xtiff/Makefile contrib/iptcutil/Makefile contrib/mfs/Makefile contrib/pds/Makefile contrib/ras/Makefile contrib/stream/Makefile contrib/tags/Makefile contrib/win_dib/Makefile libtiff-4.pc libtiff/Makefile man/Makefile port/Makefile test/Makefile tools/Makefile"
+ 
+ cat >confcache <<\_ACEOF
+ # This file is a shell script that caches the results of configure
+@@ -22095,9 +22095,6 @@
+     "contrib/stream/Makefile") CONFIG_FILES="$CONFIG_FILES contrib/stream/Makefile" ;;
+     "contrib/tags/Makefile") CONFIG_FILES="$CONFIG_FILES contrib/tags/Makefile" ;;
+     "contrib/win_dib/Makefile") CONFIG_FILES="$CONFIG_FILES contrib/win_dib/Makefile" ;;
+-    "html/Makefile") CONFIG_FILES="$CONFIG_FILES html/Makefile" ;;
+-    "html/images/Makefile") CONFIG_FILES="$CONFIG_FILES html/images/Makefile" ;;
+-    "html/man/Makefile") CONFIG_FILES="$CONFIG_FILES html/man/Makefile" ;;
+     "libtiff-4.pc") CONFIG_FILES="$CONFIG_FILES libtiff-4.pc" ;;
+     "libtiff/Makefile") CONFIG_FILES="$CONFIG_FILES libtiff/Makefile" ;;
+     "man/Makefile") CONFIG_FILES="$CONFIG_FILES man/Makefile" ;;
+--- a/Makefile.in	2017-05-22 01:49:35.000000000 +0700
++++ b/Makefile.in	2017-06-12 02:47:22.000000000 +0700
+@@ -436,7 +436,7 @@
+ 	nmake.opt
+ 
+ dist_doc_DATA = $(docfiles)
+-SUBDIRS = port libtiff tools build contrib test man html
++SUBDIRS = port libtiff tools build contrib test man
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = libtiff-4.pc
+ 
+--- a/Makefile.am	2015-09-07 02:30:46.000000000 +0700
++++ b/Makefile.am	2017-06-12 02:46:47.000000000 +0700
+@@ -61,7 +61,7 @@
+ 	rm -rf $(distdir)/_build/cmake
+ 	rm -rf $(distdir)/_inst/cmake
+ 
+-SUBDIRS = port libtiff tools build contrib test man html
++SUBDIRS = port libtiff tools build contrib test man
+ 
+ release:
+ 	(rm -f $(top_srcdir)/RELEASE-DATE && echo $(LIBTIFF_RELEASE_DATE) > $(top_srcdir)/RELEASE-DATE)
+


### PR DESCRIPTION
We've been running those versions without problems, only two needed an extra patch:
* a python2 typo in 2.7.14
* disable generating libtiff html docs (which would fail)
  