### PR TITLE
Proposal 05.

### DIFF
--- a/modulesets-stable/gtk-osx-network.modules
+++ b/modulesets-stable/gtk-osx-network.modules
@@ -39,8 +39,8 @@
   <autotools id="openssl" autogen-sh="Configure" autogenargs="shared "
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s --openssldir=%(prefix)s/etc/ssl %(autogenargs)s"
              makeinstallargs="install_sw" supports-non-srcdir-builds="no">
-    <branch module="openssl-1.1.0g.tar.gz" version="1.1.0g" repo="openssl"
-            hash="sha256:de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af"/>
+    <branch module="openssl-1.1.1c.tar.gz" version="1.1.1c" repo="openssl"
+            hash="sha256:f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90"/>
   </autotools>
 
   <!-- Rudely demands TeX to build documentation -->
@@ -103,7 +103,7 @@
     <branch repo="github-tarball" version="0.20.2"
             module="rockdaboot/libpsl/releases/download/libpsl-0.20.2/libpsl-0.20.2.tar.gz" />
   </autotools>
-  
+
   <autotools id="libsoup" autogen-sh="configure"
              autogenargs="set_more_warnings=no --enable-introspection=no">
     <branch module="libsoup/2.64/libsoup-2.64.2.tar.xz" version="2.64.2"

--- a/modulesets-unstable/gtk-osx-network.modules
+++ b/modulesets-unstable/gtk-osx-network.modules
@@ -47,8 +47,8 @@
   <autotools id="openssl" autogen-sh="Configure" autogenargs="shared"
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s --openssldir=%(prefix)s/etc/ssl %(autogenargs)s"
              makeinstallargs="install_sw" supports-non-srcdir-builds="no">
-    <branch module="openssl-1.1.0g.tar.gz" version="1.1.0g" repo="openssl"
-            hash="sha256:de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af"/>
+    <branch module="openssl-1.1.1c.tar.gz" version="1.1.1c" repo="openssl"
+            hash="sha256:f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90"/>
   </autotools>
 
   <!-- Rudely demands TeX to build documentation -->

--- a/modulesets/gtk-osx-network.modules
+++ b/modulesets/gtk-osx-network.modules
@@ -43,8 +43,8 @@
   <autotools id="openssl" autogen-sh="Configure" autogenargs="shared"
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s --openssldir=%(prefix)s/etc/ssl %(autogenargs)s"
              makeinstallargs="install_sw" supports-non-srcdir-builds="no">
-    <branch module="openssl-1.1.0g.tar.gz" version="1.1.0g" repo="openssl"
-            hash="sha256:de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af"/>
+    <branch module="openssl-1.1.1c.tar.gz" version="1.1.1c" repo="openssl"
+            hash="sha256:f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90"/>
   </autotools>
 
   <!-- Rudely demands TeX to build documentation -->
@@ -105,7 +105,7 @@
   <autotools id="libpsl" autogen-sh='configure'>
     <branch repo="github" tag="libpsl-0.20.2" module="rockdaboot/libpsl"/>
   </autotools>
-  
+
   <autotools id="libsoup"
              autogenargs="set_more_warnings=no --enable-introspection=no">
     <branch revision="gnome-3-30"/>


### PR DESCRIPTION
This current version looks too old and thoroughly depreciated due to security weaknesses.
See https://www.openssl.org/source:
All users of 1.0.2 and 1.1.0 are encouraged to upgrade to 1.1.1 as soon as possible.