### PR TITLE
gtk-osx-bootstrap updates: libpng 1.6.37, libxml2 2.9.9, libxslt 1.1.34

### DIFF
--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -35,8 +35,8 @@
   </autotools>
 
   <autotools id="libpng" autogenargs="--enable-shared" autogen-sh="configure">
-    <branch version="1.6.34" module="libpng/libpng-1.6.34.tar.xz"
-            hash="sha256:2f1e960d92ce3b3abd03d06dfec9637dfbd22febf107a536b44f7a47c60659f6"
+    <branch version="1.6.37" module="libpng/libpng-1.6.37.tar.xz"
+            hash="sha256:505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca"
             repo="sourceforge"/>
     <dependencies>
       <dep package="zlib"/>
@@ -52,6 +52,7 @@
 
   <autotools id="libtiff" autogen-sh="configure" autogenargs="--without-x">
     <branch version="4.1.0" module="libtiff/tiff-4.1.0.tar.gz"
+	    hash="sha156:5d29f32517dadb6dbcd1255ea5bbc93a2b54b94fbf83653b4d65c7d6775b8634"
 	    repo="libtiff">
 	<patch file="https://raw.githubusercontent.com/totaam/gtk-osx-build/master/patches/tiff-nohtml.patch" strip="1" />
     </branch>
@@ -68,7 +69,8 @@
 
   <autotools id="libxml2" autogen-sh="configure"
              autogenargs='--libdir="$JHBUILD_LIBDIR" --with-python'>
-    <branch version="2.9.8" module="libxml2-2.9.8.tar.gz"
+    <branch version="2.9.9" module="libxml2-2.9.9.tar.gz"
+            hash="sha256:94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871"
 	    repo="xmlsoft.org"/>
     <after>
       <dep package="python"/>
@@ -77,8 +79,8 @@
   </autotools>
 
   <autotools id="libxslt" autogen-sh="configure">
-    <branch version="1.1.32" module="libxslt-1.1.32.tar.gz"
-      hash="sha256:526ecd0abaf4a7789041622c3950c0e7f2c4c8835471515fd77eec684a355460"
+    <branch version="1.1.34" module="libxslt-1.1.34.tar.gz"
+            hash="sha256:98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f"
 	    repo="xmlsoft.org"/>
     <dependencies>
       <dep package="libxml2"/>


### PR DESCRIPTION
Also add missing hash for libtiff