### PR TITLE
For upstream

### DIFF
--- a/gtk-osx-setup.sh
+++ b/gtk-osx-setup.sh
@@ -57,7 +57,7 @@ envvar DEV_SRC_ROOT "$DEVROOT/Source"
 envvar PYENV_INSTALL_ROOT "$DEV_SRC_ROOT/pyenv"
 envvar PYENV_ROOT "$DEVPREFIX/share/pyenv"
 envvar PIP_CONFIG_DIR "$HOME/.config/pip"
-envvar PYTHON_VERSION 3.10.2
+envvar PYTHON_VERSION 3.10.10
 
 export PYTHONWARNINGS=ignore:DEPRECATION::pip._internal.cli.base_command
 

--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -26,9 +26,6 @@
   <repository name="icon-theme"
               href="http://icon-theme.freedesktop.org/releases/"
               type="tarball" />
-  <repository name="xmlsoft.org"
-              href="ftp://xmlsoft.org/libxml2/"
-              type="tarball" />
   <repository name="git.gnome.org"
               href="https://gitlab.gnome.org/GNOME"
               type="git" />
@@ -83,13 +80,9 @@
   <autotools id="libxml2"
              autogen-sh="autoreconf"
              autogenargs='--libdir="$JHBUILD_LIBDIR" --with-python'>
-             
-    <branch module="libxml2-2.9.12.tar.gz"
-            version="2.9.12"
-            hash="sha256:c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92"
-            repo="xmlsoft.org">
-      <patch file="libxml2-python-config.patch"
-             strip="1" />
+    <branch module="libxml2/2.10/libxml2-2.10.3.tar.xz"
+            version="2.10.3"
+            hash="sha256:5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c">
     </branch>
     <after>
       <dep package="python3" />
@@ -98,10 +91,9 @@
   <!---->
   <autotools id="libxslt"
              autogen-sh="configure">
-    <branch module="libxslt-1.1.34.tar.gz"
-            version="1.1.34"
-            hash="sha256:98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f"
-            repo="xmlsoft.org" />
+    <branch module="libxslt/1.1/libxslt-1.1.37.tar.xz"
+            version="1.1.37"
+            hash="sha256:3a4b27dc8027ccd6146725950336f1ec520928f320f144eb5fa7990ae6123ab4" />
     <dependencies>
       <dep package="libxml2" />
     </dependencies>

--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -59,9 +59,9 @@
   <autotools id="libtiff"
              autogen-sh="configure"
              autogenargs="--without-x">
-    <branch module="libtiff/tiff-4.4.0.tar.gz"
-            version="4.4.0"
-            hash="sha256:917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed"
+    <branch module="libtiff/tiff-4.5.0.tar.gz"
+            version="4.5.0"
+            hash="sha256:c7a1d9296649233979fa3eacffef3fa024d73d05d589cb622727b5b08c423464"
             repo="libtiff">
       <patch file="tiff-nohtml.patch"
              strip="1" />

--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -39,10 +39,9 @@
   <autotools id="libpng"
              autogen-sh="configure"
              autogenargs="--enable-shared">
-    <branch module="libpng/libpng-1.6.38.tar.xz"
-            version="1.6.38"
-            hash="sha256:b3683e8b8111ebf6f1ac004ebb6b0c975cd310ec469d98364388e9cedbfa68be"
-            repo="sourceforge" />
+    <branch version="1.6.39" module="libpng/libpng-1.6.39.tar.xz"
+            hash="sha256:1f4696ce70b4ee5f85f1e1623dc1229b210029fa4b7aee573df3e2ba7b036937"
+            repo="sourceforge"/>
     <dependencies>
       <dep package="zlib" />
     </dependencies>

--- a/modulesets-stable/gtk-osx-gstreamer.modules
+++ b/modulesets-stable/gtk-osx-gstreamer.modules
@@ -24,9 +24,9 @@
   <meson id="liborc"
          mesonargs="-Dgtk_doc=disabled -Dbenchmarks=disabled -Dexamples=disabled -Dtests=disabled">
 
-    <branch module="orc/orc-0.4.32.tar.xz"
-            version="0.4.32"
-            hash="sha256:a66e3d8f2b7e65178d786a01ef61f2a0a0b4d0b8370de7ce134ba73da4af18f0" />
+    <branch module="orc/orc-0.4.33.tar.xz"
+            version="0.4.33"
+            hash="sha256:844e6d7db8086f793f57618d3d4b68d29d99b16034e71430df3c21cfd3c3542a" />
   </meson>
   <!---->
   <autotools id="faad2"

--- a/modulesets-stable/gtk-osx-gstreamer.modules
+++ b/modulesets-stable/gtk-osx-gstreamer.modules
@@ -41,10 +41,9 @@
   <!---->
   <autotools id="nasm"
              autogen-sh="configure">
-    <branch module="2.15.05/nasm-2.15.05.tar.xz"
-            version="2.15.05"
-            hash="sha256:3caf6729c1073bf96629b57cee31eeb54f4f8129b01902c73428836550b30a3f"
-            repo="nasm" />
+    <branch repo="nasm" version="2.16.01"
+            module="2.16.01/nasm-2.16.01.tar.xz"
+            hash="sha256:c77745f4802375efeee2ec5c0ad6b7f037ea9c87c92b149a9637ff099f162558"/>
   </autotools>
   <!---->
   <autotools id="ffmpeg"

--- a/modulesets-stable/gtk-osx-gstreamer.modules
+++ b/modulesets-stable/gtk-osx-gstreamer.modules
@@ -61,9 +61,9 @@
   </autotools>
   <!---->
   <meson id="gstreamer">
-    <branch module="gstreamer/gstreamer-1.18.4.tar.xz"
-            version="1.18.4"
-            hash="sha256:9aeec99b38e310817012aa2d1d76573b787af47f8a725a65b833880a094dfbc5">
+    <branch module="gstreamer/gstreamer-1.22.0.tar.xz"
+            version="1.22.0"
+            hash="sha256:78d21b5469ac93edafc6d8ceb63bc82f6cbbee94d2f866cca6b9252157ee0a09">
     </branch>
     <after>
       <dep package="glib" />
@@ -72,9 +72,9 @@
   <!---->
   <meson id="gst-plugins-base"
          mesonargs="-Dexamples=disabled -Ddoc=disabled">
-    <branch module="gst-plugins-base/gst-plugins-base-1.18.4.tar.xz"
-            version="1.18.4"
-            hash="sha256:29e53229a84d01d722f6f6db13087231cdf6113dd85c25746b9b58c3d68e8323" />
+    <branch module="gst-plugins-base/gst-plugins-base-1.22.0.tar.xz"
+            version="1.22.0"
+            hash="sha256:f53672294f3985d56355c8b1df8f6b49c8c8721106563e19f53be3507ff2229d" />
     <dependencies>
       <dep package="gstreamer" />
       <dep package="liborc" />
@@ -83,9 +83,9 @@
   </meson>
   <!---->
   <meson id="gst-plugins-good">
-    <branch module="gst-plugins-good/gst-plugins-good-1.18.4.tar.xz"
-            version="1.18.4"
-            hash="sha256:b6e50e3a9bbcd56ee6ec71c33aa8332cc9c926b0c1fae995aac8b3040ebe39b0">
+    <branch module="gst-plugins-good/gst-plugins-good-1.22.0.tar.xz"
+            version="1.22.0"
+            hash="sha256:582e617271e7f314d1a2211e3e3856ae2e4303c8c0d6114e9c4a5ea5719294b0">
     </branch>
     <dependencies>
       <dep package="gstreamer" />
@@ -94,9 +94,9 @@
   </meson>
   <!---->
   <meson id="gst-plugins-ugly">
-    <branch module="gst-plugins-ugly/gst-plugins-ugly-1.18.4.tar.xz"
-            version="1.18.4"
-            hash="sha256:218df0ce0d31e8ca9cdeb01a3b0c573172cc9c21bb3d41811c7820145623d13c" />
+    <branch module="gst-plugins-ugly/gst-plugins-ugly-1.22.0.tar.xz"
+            version="1.22.0"
+            hash="sha256:a644dc981afa2d8d3a913f763ab9523c0620ee4e65a7ec73c7721c29da3c5a0c" />
     <dependencies>
       <dep package="gstreamer" />
       <dep package="gst-plugins-base" />
@@ -104,9 +104,9 @@
   </meson>
   <!---->
   <meson id="gst-plugins-bad">
-    <branch module="gst-plugins-bad/gst-plugins-bad-1.18.4.tar.xz"
-            version="1.18.4"
-            hash="sha256:74e806bc5595b18c70e9ca93571e27e79dfb808e5d2e7967afa952b52e99c85f" />
+    <branch module="gst-plugins-bad/gst-plugins-bad-1.22.0.tar.xz"
+            version="1.22.0"
+            hash="sha256:3c9d9300f5f4fb3e3d36009379d1fb6d9ecd79c1a135df742b8a68417dd663a1" />
     <dependencies>
       <dep package="gstreamer" />
       <dep package="gst-plugins-base" />
@@ -116,9 +116,9 @@
   </meson>
   <!---->
   <meson id="gst-libav">
-    <branch module="gst-libav/gst-libav-1.18.4.tar.xz"
-            version="1.18.4"
-            hash="sha256:344a463badca216c2cef6ee36f9510c190862bdee48dc4591c0a430df7e8c396" />
+    <branch module="gst-libav/gst-libav-1.22.0.tar.xz"
+            version="1.22.0"
+            hash="sha256:0e48407b4905227a260213dbda84cba3812f0530fc7a75b43829102ef82810f1" />
     <dependencies>
       <dep package="gstreamer" />
       <dep package="gst-plugins-base" />

--- a/modulesets-stable/gtk-osx-python.modules
+++ b/modulesets-stable/gtk-osx-python.modules
@@ -41,9 +41,9 @@
   <autotools id="python3"
              autogen-sh="configure"
              autogenargs="--enable-shared">
-    <branch module="3.10.2/Python-3.10.2.tar.xz"
-            version="3.10.2"
-            hash="sha256:17de3ac7da9f2519aa9d64378c603a73a0e9ad58dffa8812e45160c086de64c7"
+    <branch module="3.10.10/Python-3.10.10.tar.xz"
+            version="3.10.10"
+            hash="sha256:0419e9085bf51b7a672009b3f50dbf1859acdf18ba725d0ec19aa5c8503f0ea3"
             repo="python" />
     <dependencies>
       <dep package='readline' />

--- a/modulesets-stable/gtk-osx-random.modules
+++ b/modulesets-stable/gtk-osx-random.modules
@@ -288,9 +288,9 @@
   <!---->
   <autotools id='readline'
              autogen-sh="configure">
-    <branch module="readline/readline-8.1.tar.gz"
-            version="8.1"
-            hash="sha256:f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02"
+    <branch module="readline/readline-8.2.tar.gz"
+            version="8.2"
+            hash="sha256:3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35"
             repo="ftp.gnu.org" />
   </autotools>
   <!---->

--- a/modulesets-stable/gtk-osx.modules
+++ b/modulesets-stable/gtk-osx.modules
@@ -241,9 +241,9 @@
   <!---->
   <meson id="fribidi"
          mesonargs="-Ddocs=false">
-    <branch module="fribidi/fribidi/releases/download/v1.0.11/fribidi-1.0.11.tar.xz"
-            version="1.0.11"
-            hash="sha256:30f93e9c63ee627d1a2cedcf59ac34d45bf30240982f99e44c6e015466b4e73d"
+    <branch module="fribidi/fribidi/releases/download/v1.0.12/fribidi-1.0.12.tar.xz"
+            version="1.0.12"
+            hash="sha256:0cd233f97fc8c67bb3ac27ce8440def5d3ffacf516765b91c2cc654498293495"
             repo="github-tarball" />
     <!--
     <dependencies>

--- a/modulesets-stable/gtk-osx.modules
+++ b/modulesets-stable/gtk-osx.modules
@@ -94,9 +94,9 @@
   <autotools id="libffi"
              autogen-sh="configure"
              autogenargs="--disable-multi-os-directory">
-    <branch module="libffi/libffi/releases/download/v3.4.3/libffi-3.4.3.tar.gz"
-            version="3.4.3"
-            hash="sha256:4416dd92b6ae8fcb5b10421e711c4d3cb31203d77521a77d85d0102311e6c3b8"
+    <branch module="libffi/libffi/releases/download/v3.4.4/libffi-3.4.4.tar.gz"
+            version="3.4.4"
+            hash="sha256:d66c56ad259a82cf2a9dfc408b32bf5da52371500b84745f7fb8b645712df676"
             repo="github-tarball" />
   </autotools>
   <!---->

--- a/modulesets-stable/gtk-osx.modules
+++ b/modulesets-stable/gtk-osx.modules
@@ -212,9 +212,9 @@
   </meson>
   <!---->
   <meson id="gobject-introspection">
-    <branch module="gobject-introspection/1.72/gobject-introspection-1.72.0.tar.xz"
-            version="1.72.0"
-            hash="sha256:02fe8e590861d88f83060dd39cda5ccaa60b2da1d21d0f95499301b186beaabc">
+    <branch module="gobject-introspection/1.72/gobject-introspection-1.72.1.tar.xz"
+            version="1.72.1"
+            hash="sha256:012e313186e3186cf0fde6decb57d970adf90e6b1fac5612fe69cbb5ba99543a">
     </branch>
     <dependencies>
       <dep package="glib" />

--- a/modulesets-unstable/gtk-osx-bootstrap.modules
+++ b/modulesets-unstable/gtk-osx-bootstrap.modules
@@ -33,10 +33,12 @@
   </autotools>
 
   <autotools id="libtiff" autogen-sh="configure" autogenargs="--without-x">
-    <branch version="4.4.0" module="libtiff/tiff-4.4.0.tar.gz"
-            repo="libtiff"
-            hash="sha256:917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed">
-	<patch file="tiff-nohtml.patch" strip="1" />
+    <branch module="libtiff/tiff-4.5.0.tar.gz"
+            version="4.5.0"
+            hash="sha256:c7a1d9296649233979fa3eacffef3fa024d73d05d589cb622727b5b08c423464"
+            repo="libtiff">
+      <patch file="tiff-nohtml.patch"
+             strip="1" />
     </branch>
     <dependencies>
       <dep package="libjpeg"/>

--- a/modulesets-unstable/gtk-osx-bootstrap.modules
+++ b/modulesets-unstable/gtk-osx-bootstrap.modules
@@ -14,8 +14,6 @@
 	      href="http://download.osgeo.org/"/>
   <repository type="tarball" name="icon-theme"
 	      href="http://icon-theme.freedesktop.org/releases/"/>
-  <repository type="tarball" name="xmlsoft.org"
-	      href="ftp://xmlsoft.org/libxml2/"/>
  <repository type="tarball" name="itstool" href="http://files.itstool.org/"/>
   <repository type="tarball" name="github-tarball" href="https://github.com/"/>
 

--- a/modulesets-unstable/gtk-osx-bootstrap.modules
+++ b/modulesets-unstable/gtk-osx-bootstrap.modules
@@ -18,8 +18,8 @@
   <repository type="tarball" name="github-tarball" href="https://github.com/"/>
 
   <autotools id="libpng" autogenargs="--enable-shared" autogen-sh="configure">
-    <branch version="1.6.38" module="libpng/libpng-1.6.38.tar.xz"
-            hash="sha256:b3683e8b8111ebf6f1ac004ebb6b0c975cd310ec469d98364388e9cedbfa68be"
+    <branch version="1.6.39" module="libpng/libpng-1.6.39.tar.xz"
+            hash="sha256:1f4696ce70b4ee5f85f1e1623dc1229b210029fa4b7aee573df3e2ba7b036937"
             repo="sourceforge"/>
     <dependencies>
       <dep package="zlib"/>

--- a/modulesets-unstable/gtk-osx-gstreamer.modules
+++ b/modulesets-unstable/gtk-osx-gstreamer.modules
@@ -29,9 +29,9 @@
   </autotools>
 
   <autotools id="nasm" autogen-sh="configure">
-    <branch repo="nasm" version="2.15.05"
-            module="2.15.05/nasm-2.15.05.tar.xz"
-            hash="sha256:3caf6729c1073bf96629b57cee31eeb54f4f8129b01902c73428836550b30a3f"/>
+    <branch repo="nasm" version="2.16.01"
+            module="2.16.01/nasm-2.16.01.tar.xz"
+            hash="sha256:c77745f4802375efeee2ec5c0ad6b7f037ea9c87c92b149a9637ff099f162558"/>
   </autotools>
 
   <autotools id="ffmpeg" autogen-sh="configure"

--- a/modulesets-unstable/gtk-osx-python.modules
+++ b/modulesets-unstable/gtk-osx-python.modules
@@ -22,8 +22,10 @@
   </metamodule>
 
   <autotools id="python3" autogenargs="--enable-shared" autogen-sh="autoreconf">
-    <branch repo="python" module="3.10.2/Python-3.10.2.tar.xz" version="3.10.2"
-            hash="sha256:17de3ac7da9f2519aa9d64378c603a73a0e9ad58dffa8812e45160c086de64c7"/>
+    <branch module="3.10.10/Python-3.10.10.tar.xz"
+            version="3.10.10"
+            hash="sha256:0419e9085bf51b7a672009b3f50dbf1859acdf18ba725d0ec19aa5c8503f0ea3"
+            repo="python" />
     <dependencies>
       <dep package='readline'/>
       <dep package="openssl" /> <!-- For hashlib -->

--- a/modulesets-unstable/gtk-osx-random.modules
+++ b/modulesets-unstable/gtk-osx-random.modules
@@ -210,9 +210,9 @@
   </autotools>
 
   <autotools id='readline' autogen-sh="configure">
-    <branch repo="ftp.gnu.org" module="readline/readline-8.1.tar.gz"
-            version="8.1"
-            hash="sha256:f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02">
+    <branch repo="ftp.gnu.org" module="readline/readline-8.2.tar.gz"
+            version="8.2"
+            hash="sha256:3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35">
     </branch>
   </autotools>
 

--- a/modulesets/gtk-osx-bootstrap.modules
+++ b/modulesets/gtk-osx-bootstrap.modules
@@ -14,8 +14,6 @@
 	      href="http://download.osgeo.org/"/>
   <repository type="tarball" name="icon-theme"
 	      href="http://icon-theme.freedesktop.org/releases/"/>
-  <repository type="tarball" name="xmlsoft.org"
-	      href="ftp://xmlsoft.org/libxml2/"/>
   <repository type="tarball" name="itstool" href="http://files.itstool.org/"/>
   <repository type="tarball" name="github-tarball" href="https://github.com/"/>
 
@@ -53,9 +51,9 @@
 
   <autotools id="libxml2" autogen-sh="autoreconf"
              autogenargs='--libdir="$JHBUILD_LIBDIR" --with-python'>
-    <branch version="2.9.12" module="libxml2-2.9.12.tar.gz"
-            repo="xmlsoft.org"
-            hash="sha256:c8d6681e38c56f172892c85ddc0852e1fd4b53b4209e7f4ebf17f7e2eae71d92">
+    <branch module="libxml2/2.10/libxml2-2.10.3.tar.xz"
+            version="2.10.3"
+            hash="sha256:5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c">
       <patch file="libxml2-python-config.patch" strip="1"/>
     </branch>
     <after>
@@ -64,9 +62,9 @@
   </autotools>
 
   <autotools id="libxslt" autogen-sh="configure">
-    <branch version="1.1.34" module="libxslt-1.1.34.tar.gz"
-            hash="sha256:98b1bd46d6792925ad2dfe9a87452ea2adebf69dcb9919ffd55bf926a7f93f7f"
-	    repo="xmlsoft.org"/>
+    <branch module="libxslt/1.1/libxslt-1.1.37.tar.xz"
+            version="1.1.37"
+            hash="sha256:3a4b27dc8027ccd6146725950336f1ec520928f320f144eb5fa7990ae6123ab4" />
     <dependencies>
       <dep package="libxml2"/>
     </dependencies>

--- a/modulesets/gtk-osx-bootstrap.modules
+++ b/modulesets/gtk-osx-bootstrap.modules
@@ -33,10 +33,12 @@
   </autotools>
 
   <autotools id="libtiff" autogen-sh="configure" autogenargs="--without-x">
-    <branch version="4.4.0" module="libtiff/tiff-4.4.0.tar.gz"
-            repo="libtiff"
-            hash="sha256:917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed">
-	<patch file="tiff-nohtml.patch" strip="1" />
+    <branch module="libtiff/tiff-4.5.0.tar.gz"
+            version="4.5.0"
+            hash="sha256:c7a1d9296649233979fa3eacffef3fa024d73d05d589cb622727b5b08c423464"
+            repo="libtiff">
+      <patch file="tiff-nohtml.patch"
+             strip="1" />
     </branch>
     <dependencies>
       <dep package="libjpeg"/>

--- a/modulesets/gtk-osx-bootstrap.modules
+++ b/modulesets/gtk-osx-bootstrap.modules
@@ -18,8 +18,8 @@
   <repository type="tarball" name="github-tarball" href="https://github.com/"/>
 
   <autotools id="libpng" autogenargs="--enable-shared" autogen-sh="configure">
-    <branch version="1.6.38" module="libpng/libpng-1.6.38.tar.xz"
-            hash="sha256:b3683e8b8111ebf6f1ac004ebb6b0c975cd310ec469d98364388e9cedbfa68be"
+    <branch version="1.6.39" module="libpng/libpng-1.6.39.tar.xz"
+            hash="sha256:1f4696ce70b4ee5f85f1e1623dc1229b210029fa4b7aee573df3e2ba7b036937"
             repo="sourceforge"/>
     <dependencies>
       <dep package="zlib"/>

--- a/modulesets/gtk-osx-gstreamer.modules
+++ b/modulesets/gtk-osx-gstreamer.modules
@@ -24,9 +24,9 @@
   </autotools>
 
   <autotools id="nasm" autogen-sh="configure">
-    <branch repo="nasm" version="2.15.05"
-            module="2.15.05/nasm-2.15.05.tar.xz"
-            hash="sha256:3caf6729c1073bf96629b57cee31eeb54f4f8129b01902c73428836550b30a3f"/>
+    <branch repo="nasm" version="2.16.01"
+            module="2.16.01/nasm-2.16.01.tar.xz"
+            hash="sha256:c77745f4802375efeee2ec5c0ad6b7f037ea9c87c92b149a9637ff099f162558"/>
   </autotools>
 
   <autotools id="ffmpeg" autogen-sh="configure"

--- a/modulesets/gtk-osx-python.modules
+++ b/modulesets/gtk-osx-python.modules
@@ -21,8 +21,10 @@
   </metamodule>
 
   <autotools id="python3" autogenargs="--enable-shared" autogen-sh="configure">
-    <branch repo="python" module="3.10.2/Python-3.10.2.tar.xz" version="3.10.2"
-            hash="sha256:17de3ac7da9f2519aa9d64378c603a73a0e9ad58dffa8812e45160c086de64c7"/>
+    <branch module="3.10.10/Python-3.10.10.tar.xz"
+            version="3.10.10"
+            hash="sha256:0419e9085bf51b7a672009b3f50dbf1859acdf18ba725d0ec19aa5c8503f0ea3"
+            repo="python" />
     <dependencies>
       <dep package='readline'/>
       <dep package="openssl" /> <!-- For hashlib -->

--- a/modulesets/gtk-osx-random.modules
+++ b/modulesets/gtk-osx-random.modules
@@ -195,9 +195,9 @@
   </autotools>
 
   <autotools id='readline' autogen-sh="configure">
-    <branch repo="ftp.gnu.org" module="readline/readline-8.1.tar.gz"
-            version="8.1"
-            hash="sha256:f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02">
+    <branch repo="ftp.gnu.org" module="readline/readline-8.2.tar.gz"
+            version="8.2"
+            hash="sha256:3feb7171f16a84ee82ca18a36d7b9be109a52c04f492a053331d7d1095007c35">
     </branch>
   </autotools>
 

--- a/modulesets/gtk-osx.modules
+++ b/modulesets/gtk-osx.modules
@@ -163,7 +163,7 @@
   </meson>
 
   <meson id="fribidi" mesonargs="-Ddocs=false">
-    <branch module="fribidi/fribidi" repo="github" tag="v1.0.11"/>
+    <branch module="fribidi/fribidi" repo="github" tag="v1.0.12"/>
     <dependencies>
       <!--dep package="c2man"/ -->
     </dependencies>

--- a/modulesets/gtk-osx.modules
+++ b/modulesets/gtk-osx.modules
@@ -61,7 +61,7 @@
 
   <autotools id="libffi" autogenargs="--disable-multi-os-directory"
              autogen-sh="autoreconf">
-    <branch module="atgreen/libffi" repo="github" tag="v3.4.3"/>
+    <branch module="atgreen/libffi" repo="github" tag="v3.4.4"/>
   </autotools>
 
   <autotools id="libpcre" autogen-sh="configure"

--- a/patches/tiff-nohtml.patch
+++ b/patches/tiff-nohtml.patch
@@ -1,44 +1,57 @@
---- a/configure	2017-05-22 01:49:37.000000000 +0700
-+++ b/configure	2017-06-12 02:37:01.000000000 +0700
-@@ -20927,7 +20927,7 @@
- ac_config_headers="$ac_config_headers libtiff/tif_config.h libtiff/tiffconf.h"
+--- a/Makefile.in	2023-02-19 19:31:46.135333554 +0700
++++ b/Makefile.in	2023-02-19 19:32:28.379010562 +0700
+@@ -148,9 +148,9 @@
+ SOURCES =
+ DIST_SOURCES =
+ RECURSIVE_TARGETS = all-recursive check-recursive cscopelist-recursive \
+-	ctags-recursive dvi-recursive html-recursive info-recursive \
++	ctags-recursive dvi-recursive info-recursive \
+ 	install-data-recursive install-dvi-recursive \
+-	install-exec-recursive install-html-recursive \
++	install-exec-recursive \
+ 	install-info-recursive install-pdf-recursive \
+ 	install-ps-recursive install-recursive installcheck-recursive \
+ 	installdirs-recursive pdf-recursive ps-recursive \
+@@ -400,7 +400,6 @@
+ host_cpu = @host_cpu@
+ host_os = @host_os@
+ host_vendor = @host_vendor@
+-htmldir = @htmldir@
+ includedir = @includedir@
+ infodir = @infodir@
+ install_sh = @install_sh@
+@@ -908,10 +907,6 @@
  
+ dvi-am:
  
--ac_config_files="$ac_config_files Makefile build/Makefile contrib/Makefile contrib/addtiffo/Makefile contrib/dbs/Makefile contrib/dbs/xtiff/Makefile contrib/iptcutil/Makefile contrib/mfs/Makefile contrib/pds/Makefile contrib/ras/Makefile contrib/stream/Makefile contrib/tags/Makefile contrib/win_dib/Makefile html/Makefile html/images/Makefile html/man/Makefile libtiff-4.pc libtiff/Makefile man/Makefile port/Makefile test/Makefile tools/Makefile"
-+ac_config_files="$ac_config_files Makefile build/Makefile contrib/Makefile contrib/addtiffo/Makefile contrib/dbs/Makefile contrib/dbs/xtiff/Makefile contrib/iptcutil/Makefile contrib/mfs/Makefile contrib/pds/Makefile contrib/ras/Makefile contrib/stream/Makefile contrib/tags/Makefile contrib/win_dib/Makefile libtiff-4.pc libtiff/Makefile man/Makefile port/Makefile test/Makefile tools/Makefile"
+-html: html-recursive
+-
+-html-am:
+-
+ info: info-recursive
  
- cat >confcache <<\_ACEOF
- # This file is a shell script that caches the results of configure
-@@ -22095,9 +22095,6 @@
-     "contrib/stream/Makefile") CONFIG_FILES="$CONFIG_FILES contrib/stream/Makefile" ;;
-     "contrib/tags/Makefile") CONFIG_FILES="$CONFIG_FILES contrib/tags/Makefile" ;;
-     "contrib/win_dib/Makefile") CONFIG_FILES="$CONFIG_FILES contrib/win_dib/Makefile" ;;
--    "html/Makefile") CONFIG_FILES="$CONFIG_FILES html/Makefile" ;;
--    "html/images/Makefile") CONFIG_FILES="$CONFIG_FILES html/images/Makefile" ;;
--    "html/man/Makefile") CONFIG_FILES="$CONFIG_FILES html/man/Makefile" ;;
-     "libtiff-4.pc") CONFIG_FILES="$CONFIG_FILES libtiff-4.pc" ;;
-     "libtiff/Makefile") CONFIG_FILES="$CONFIG_FILES libtiff/Makefile" ;;
-     "man/Makefile") CONFIG_FILES="$CONFIG_FILES man/Makefile" ;;
---- a/Makefile.in	2017-05-22 01:49:35.000000000 +0700
-+++ b/Makefile.in	2017-06-12 02:47:22.000000000 +0700
-@@ -436,7 +436,7 @@
- 	nmake.opt
+ info-am:
+@@ -924,10 +919,6 @@
  
- dist_doc_DATA = $(docfiles)
--SUBDIRS = port libtiff tools build contrib test man html
-+SUBDIRS = port libtiff tools build contrib test man
- pkgconfigdir = $(libdir)/pkgconfig
- pkgconfig_DATA = libtiff-4.pc
+ install-exec-am:
  
---- a/Makefile.am	2015-09-07 02:30:46.000000000 +0700
-+++ b/Makefile.am	2017-06-12 02:46:47.000000000 +0700
-@@ -61,7 +61,7 @@
- 	rm -rf $(distdir)/_build/cmake
- 	rm -rf $(distdir)/_inst/cmake
+-install-html: install-html-recursive
+-
+-install-html-am:
+-
+ install-info: install-info-recursive
  
--SUBDIRS = port libtiff tools build contrib test man html
-+SUBDIRS = port libtiff tools build contrib test man
- 
- release:
- 	(rm -f $(top_srcdir)/RELEASE-DATE && echo $(LIBTIFF_RELEASE_DATE) > $(top_srcdir)/RELEASE-DATE)
-
+ install-info-am:
+@@ -972,10 +963,10 @@
+ 	dist-all dist-bzip2 dist-gzip dist-lzip dist-shar dist-tarZ \
+ 	dist-xz dist-zip distcheck distclean distclean-generic \
+ 	distclean-hdr distclean-libtool distclean-tags distcleancheck \
+-	distdir distuninstallcheck dvi dvi-am html html-am info \
++	distdir distuninstallcheck dvi dvi-am info \
+ 	info-am install install-am install-data install-data-am \
+ 	install-dist_docDATA install-dvi install-dvi-am install-exec \
+-	install-exec-am install-html install-html-am install-info \
++	install-exec-am install-info \
+ 	install-info-am install-man install-pdf install-pdf-am \
+ 	install-pkgconfigDATA install-ps install-ps-am install-strip \
+ 	installcheck installcheck-am installdirs installdirs-am \


### PR DESCRIPTION
Replaces #80 with the following changes:
* rebased
* also updating: GStreamer 1.22.0, gobject-introspection 1.72.1, libffi 3.4.4 and libpng 1.6.39
* squashed Python 3.10 commits as requested

As for why I chose Python 3.10.10 over 3.11.2 - I'm just being conservative here, I could bump it too if you like.

FWIW: works for me(tm).