### PR TITLE
OpenSSL 3

### DIFF
--- a/modulesets-stable/gtk-osx-network.modules
+++ b/modulesets-stable/gtk-osx-network.modules
@@ -54,10 +54,8 @@
              autogenargs="shared"
              makeinstallargs="install_sw"
              supports-non-srcdir-builds="no">
-    <branch module="openssl-1.1.1s.tar.gz"
-            version="1.1.1s"
-            hash="sha256:c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa"
-            repo="openssl" />
+    <branch module="openssl-3.0.8.tar.gz" version="3.0.8" repo="openssl"
+            hash="sha256:6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e"/>
   </autotools>
   <!--
     Rudely demands TeX to build documentation

--- a/modulesets-unstable/gtk-osx-network.modules
+++ b/modulesets-unstable/gtk-osx-network.modules
@@ -37,8 +37,8 @@
   <autotools id="openssl" autogen-sh="Configure" autogenargs="shared "
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s --openssldir=%(prefix)s/etc/ssl %(autogenargs)s"
              makeinstallargs="install_sw" supports-non-srcdir-builds="no">
-    <branch module="openssl-1.1.1s.tar.gz" version="1.1.1s" repo="openssl"
-            hash="sha256:c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa"/>
+    <branch module="openssl-3.0.8.tar.gz" version="3.0.8" repo="openssl"
+            hash="sha256:6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e"/>
   </autotools>
 
   <!-- Rudely demands TeX to build documentation -->

--- a/modulesets/gtk-osx-network.modules
+++ b/modulesets/gtk-osx-network.modules
@@ -36,8 +36,8 @@
   <autotools id="openssl" autogen-sh="Configure" autogenargs="shared "
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s --openssldir=%(prefix)s/etc/ssl %(autogenargs)s"
              makeinstallargs="install_sw" supports-non-srcdir-builds="no">
-    <branch module="openssl-1.1.1s.tar.gz" version="1.1.1s" repo="openssl"
-            hash="sha256:c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa"/>
+    <branch module="openssl-3.0.8.tar.gz" version="3.0.8" repo="openssl"
+            hash="sha256:6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e"/>
   </autotools>
 
   <!-- Rudely demands TeX to build documentation -->


### PR DESCRIPTION
I haven't included this one in #81 because it is obviously more disruptive than other library updates.

FWIW, I have been using OpenSSL 3.x for a while now and apart from some minor warnings with `python3-cryptography` complaining about deprecated APIs (which can be silenced with `CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1`) it is working just fine here.