### PR TITLE
duplicate header file to fix installation paths problems

### DIFF
--- a/modulesets-stable/gtk-osx.modules
+++ b/modulesets-stable/gtk-osx.modules
@@ -337,6 +337,8 @@
              strip="1" />
       <patch file="gtk-3-24-36-match-window-size.patch"
              strip="1" />
+      <patch file="gtk-3-24-36-quartz-cocoa-access-path.patch"
+             strip="1" />
     </branch>
     <dependencies>
       <dep package="glib" />

--- a/patches/gtk-3-24-36-quartz-cocoa-access-path.patch
+++ b/patches/gtk-3-24-36-quartz-cocoa-access-path.patch
@@ -1,0 +1,86 @@
+--- a/gdk/quartz/gdkquartz-cocoa-access.h	2023-02-24 12:02:41.000000000 +0700
++++ b/gdk/quartz/gdkquartz-cocoa-access.h	2023-02-24 12:02:52.000000000 +0700
+@@ -25,7 +25,7 @@
+ 
+ #include <AppKit/AppKit.h>
+ #include <gdk/gdk.h>
+-#include "gdkquartz.h"
++#include "gdk/gdkquartz.h"
+ 
+ GDK_AVAILABLE_IN_ALL
+ NSEvent  *gdk_quartz_event_get_nsevent              (GdkEvent  *event);
+--- a/gdk/gdkquartz.h	1970-01-01 07:00:00.000000000 +0700
++++ b/gdk/gdkquartz.h	2022-12-22 21:01:18.000000000 +0700
+@@ -0,0 +1,72 @@
++
++/* gdkquartz.h
++ *
++ * Copyright (C) 2005-2007 Imendio AB
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
++ */
++
++#ifndef __GDK_QUARTZ_H__
++#define __GDK_QUARTZ_H__
++
++#include <gdk/gdk.h>
++#include <gdk/gdkprivate.h>
++
++G_BEGIN_DECLS
++
++typedef enum
++{
++  GDK_OSX_UNSUPPORTED = 0,
++  GDK_OSX_MIN = 4,
++  GDK_OSX_TIGER = 4,
++  GDK_OSX_LEOPARD = 5,
++  GDK_OSX_SNOW_LEOPARD = 6,
++  GDK_OSX_LION = 7,
++  GDK_OSX_MOUNTAIN_LION = 8,
++  GDK_OSX_MAVERICKS = 9,
++  GDK_OSX_YOSEMITE = 10,
++  GDK_OSX_EL_CAPITAN = 11,
++  GDK_OSX_SIERRA = 12,
++  GDK_OSX_HIGH_SIERRA = 13,
++  GDK_OSX_MOJAVE = 14,
++  GDK_OSX_CATALINA = 15,
++  GDK_OSX_BIGSUR = 16,
++  GDK_OSX_MONTEREY = 17,
++  GDK_OSX_VENTURA = 18,
++  GDK_OSX_CURRENT = 18,
++  GDK_OSX_NEW = 99
++} GdkOSXVersion;
++
++GDK_AVAILABLE_IN_ALL
++GdkOSXVersion gdk_quartz_osx_version (void);
++
++G_END_DECLS
++
++#define __GDKQUARTZ_H_INSIDE__
++
++#include <gdk/quartz/gdkquartzcursor.h>
++#include <gdk/quartz/gdkquartzdevice-core.h>
++#include <gdk/quartz/gdkquartzdevicemanager-core.h>
++#include <gdk/quartz/gdkquartzdisplay.h>
++#include <gdk/quartz/gdkquartzdisplaymanager.h>
++#include <gdk/quartz/gdkquartzkeys.h>
++#include <gdk/quartz/gdkquartzmonitor.h>
++#include <gdk/quartz/gdkquartzscreen.h>
++#include <gdk/quartz/gdkquartzutils.h>
++#include <gdk/quartz/gdkquartzvisual.h>
++#include <gdk/quartz/gdkquartzwindow.h>
++
++#undef __GDKQUARTZ_H_INSIDE__
++
++#endif /* __GDK_QUARTZ_H__ */


### PR DESCRIPTION
This is a slightly dirty fix, but this is the best that I could come up with - feel free to ignore if you have a better solution, or just a dislike for resulting file duplication.

The naive approach of just changing the path in the `gdk/quartz/gdkquartz-cocoa-access.h` header file just ends up breaking everything:
```patch
-#include "gdkquartz.h"
+#include "gdk/gdkquartz.h"
```
Because all the other headers use relative includes and end up not finding `gdkquartz.h`.

At least this patch generates a `gdkquartz-cocoa-access.h` file that can be used when GTK is installed.