### PR TITLE
switch to `libjpeg-turbo` as jpeg library

### DIFF
--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -17,9 +17,6 @@
   <repository name="sourceforge"
               href="http://downloads.sourceforge.net/sourceforge/"
               type="tarball" />
-  <repository name="jpeg"
-              href="http://www.ijg.org/files/"
-              type="tarball" />
   <repository name="libtiff"
               href="http://download.osgeo.org/"
               type="tarball" />
@@ -45,13 +42,14 @@
     </dependencies>
   </autotools>
   <!---->
-  <autotools id="libjpeg"
-             autogen-sh="configure">
-    <branch module="jpegsrc.v9e.tar.gz"
-            version="9e"
-            checkoutdir="jpeg-9e"
-            repo="jpeg" />
-  </autotools>
+  <cmake id="libjpeg" cmakeargs="-DCMAKE_MACOSX_RPATH=true -DCMAKE_INSTALL_PREFIX:PATH=${JHBUILD_PREFIX} -DCMAKE_INSTALL_NAME_DIR=${JHBUILD_PREFIX}/lib -DCMAKE_INSTALL_LIBDIR:PATH=lib">
+    <branch module="libjpeg-turbo/libjpeg-turbo/releases/download/3.0.3/libjpeg-turbo-3.0.3.tar.gz" version="3.0.3"
+            hash="sha256:343e789069fc7afbcdfe44dbba7dbbf45afa98a15150e079a38e60e44578865d"
+            repo="github-tarball" checkoutdir="libjpeg-turbo-3.0.3" />
+    <dependencies>
+      <dep package="nasm" />
+    </dependencies>
+  </cmake>
   <!---->
   <autotools id="libtiff"
              autogen-sh="configure"

--- a/modulesets-unstable/gtk-osx-bootstrap.modules
+++ b/modulesets-unstable/gtk-osx-bootstrap.modules
@@ -8,8 +8,6 @@
   <repository type="tarball" name="ftp.gnu.org" href="https://ftp.gnu.org/gnu/"/>
   <repository type="tarball" name="sourceforge"
               href="http://downloads.sourceforge.net/sourceforge/"/>
-  <repository type="tarball" name="jpeg"
-              href="http://www.ijg.org/files/"/>
   <repository type="tarball" name="libtiff"
 	      href="http://download.osgeo.org/"/>
   <repository type="tarball" name="icon-theme"
@@ -28,13 +26,14 @@
     </dependencies>
   </autotools>
   <!---->
-  <autotools id="libjpeg"
-             autogen-sh="configure">
-    <branch module="jpegsrc.v9e.tar.gz"
-            version="9e"
-            checkoutdir="jpeg-9e"
-            repo="jpeg" />
-  </autotools>
+  <cmake id="libjpeg" cmakeargs="-DCMAKE_MACOSX_RPATH=true -DCMAKE_INSTALL_PREFIX:PATH=${JHBUILD_PREFIX} -DCMAKE_INSTALL_NAME_DIR=${JHBUILD_PREFIX}/lib -DCMAKE_INSTALL_LIBDIR:PATH=lib">
+    <branch module="libjpeg-turbo/libjpeg-turbo/releases/download/3.0.3/libjpeg-turbo-3.0.3.tar.gz" version="3.0.3"
+            hash="sha256:343e789069fc7afbcdfe44dbba7dbbf45afa98a15150e079a38e60e44578865d"
+            repo="github-tarball" checkoutdir="libjpeg-turbo-3.0.3" />
+    <dependencies>
+      <dep package="nasm" />
+    </dependencies>
+  </cmake>
   <!---->
   <autotools id="libtiff"
              autogen-sh="configure"

--- a/modulesets/gtk-osx-bootstrap.modules
+++ b/modulesets/gtk-osx-bootstrap.modules
@@ -17,9 +17,6 @@
   <repository name="sourceforge"
               href="http://downloads.sourceforge.net/sourceforge/"
               type="tarball" />
-  <repository name="jpeg"
-              href="http://www.ijg.org/files/"
-              type="tarball" />
   <repository name="libtiff"
               href="http://download.osgeo.org/"
               type="tarball" />
@@ -41,15 +38,16 @@
       <dep package="zlib" />
     </dependencies>
   </autotools>
-  <!---->
-  <autotools id="libjpeg"
-             autogen-sh="configure">
-    <branch module="jpegsrc.v9e.tar.gz"
-            version="9e"
-            checkoutdir="jpeg-9e"
-            repo="jpeg" />
-  </autotools>
-  <!---->
+
+  <cmake id="libjpeg" cmakeargs="-DCMAKE_MACOSX_RPATH=true -DCMAKE_INSTALL_PREFIX:PATH=${JHBUILD_PREFIX} -DCMAKE_INSTALL_NAME_DIR=${JHBUILD_PREFIX}/lib -DCMAKE_INSTALL_LIBDIR:PATH=lib">
+    <branch module="libjpeg-turbo/libjpeg-turbo/releases/download/3.0.3/libjpeg-turbo-3.0.3.tar.gz" version="3.0.3"
+            hash="sha256:343e789069fc7afbcdfe44dbba7dbbf45afa98a15150e079a38e60e44578865d"
+            repo="github-tarball" checkoutdir="libjpeg-turbo-3.0.3" />
+    <dependencies>
+      <dep package="nasm" />
+    </dependencies>
+  </cmake>
+
   <autotools id="libtiff"
              autogen-sh="configure"
              autogenargs="--without-x">


### PR DESCRIPTION
All the Linux distributions have switched to [libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo) as their upstream a long time ago, as this one is actively maintained and much much faster too.

The reason why I didn't submit this PR earlier is that we had some rpath issues that needed resolving: https://github.com/Xpra-org/gtk-osx-build/issues/19#issuecomment-1879992828 - big thanks to @cpatulea for figuring out that we needed a `DCMAKE_INSTALL_NAME_DIR`.

We've been running [xpra](https://xpra.org/) with `libjpeg-turbo` for many years without issues - well, apart from the manual `rpath` fixup...