### PR TITLE
glib-no-introspection should.. disable introspection

### DIFF
--- a/modulesets-stable/gtk-osx.modules
+++ b/modulesets-stable/gtk-osx.modules
@@ -112,7 +112,7 @@
   </autotools>
   <!---->
   <meson id="glib-no-introspection"
-         mesonargs="-Dlibmount=disabled">
+         mesonargs="-Dlibmount=disabled -Dintrospection=disabled">
     <branch module="glib/2.80/glib-2.80.2.tar.xz"
             version="2.80.2"
 	    hash="sha256:b9cfb6f7a5bd5b31238fd5d56df226b2dda5ea37611475bf89f6a0f9400fe8bd" />


### PR DESCRIPTION
`modulesets-unstable` does it:
https://github.com/jralls/gtk-osx-build/blob/919a82469519973c74ff3b568219b9f3b98abbe4/modulesets-unstable/gtk-osx.modules#L76