### PR TITLE
OpenSSL 3.3.1

### DIFF
--- a/modulesets-stable/gtk-osx-network.modules
+++ b/modulesets-stable/gtk-osx-network.modules
@@ -11,9 +11,6 @@
               default="yes"
               href="https://download.gnome.org/sources/"
               type="tarball" />
-  <repository name="openssl"
-              href="https://www.openssl.org/source/"
-              type="tarball" />
   <repository name="ftp.gnu.org"
               href="https://ftp.gnu.org/gnu/"
               type="tarball" />
@@ -54,8 +51,10 @@
              autogenargs="shared"
              makeinstallargs="install_sw"
              supports-non-srcdir-builds="no">
-    <branch module="openssl-3.2.1.tar.gz" version="3.2.1" repo="openssl"
-            hash="sha256:83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39"/>
+    <branch module="openssl/openssl/releases/download/openssl-3.3.1/openssl-3.3.1.tar.gz"
+            version="3.3.1"
+            hash="sha256:777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e"
+            repo="github-tarball"/>
   </autotools>
   <!---->
   <if condition-set="arm64">

--- a/modulesets-unstable/gtk-osx-network.modules
+++ b/modulesets-unstable/gtk-osx-network.modules
@@ -4,8 +4,6 @@
 <moduleset>
   <repository name="git.gnome.org" type="git" default="yes"
               href="https://gitlab.gnome.org/GNOME"/>
-  <repository name="openssl" type="tarball"
-              href="https://www.openssl.org/source/"/>
   <repository name="lysator" type="git"
               href="https://git.lysator.liu.se/"/>
   <repository name="ftp.gnu.org" type="tarball"
@@ -37,8 +35,10 @@
   <autotools id="openssl" autogen-sh="Configure" autogenargs="shared "
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s --openssldir=%(prefix)s/etc/ssl %(autogenargs)s"
              makeinstallargs="install_sw" supports-non-srcdir-builds="no">
-    <branch module="openssl-3.2.1.tar.gz" version="3.2.1" repo="openssl"
-            hash="sha256:83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39"/>
+    <branch module="openssl/openssl/releases/download/openssl-3.3.1/openssl-3.3.1.tar.gz"
+            version="3.3.1"
+            hash="sha256:777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e"
+            repo="github-tarball"/>
   </autotools>
 
   <autotools id="libnettle" autogen-sh="autoreconf"

--- a/modulesets/gtk-osx-network.modules
+++ b/modulesets/gtk-osx-network.modules
@@ -11,9 +11,6 @@
               default="yes"
               href="https://gitlab.gnome.org/GNOME"
               type="git" />
-  <repository name="openssl"
-              href="https://www.openssl.org/source/"
-              type="tarball" />
   <repository name="lysator"
               href="https://git.lysator.liu.se/"
               type="git" />
@@ -61,8 +58,10 @@
              autogen-sh="Configure"
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s --openssldir=%(prefix)s/etc/ssl %(autogenargs)s"
              makeinstallargs="install_sw" supports-non-srcdir-builds="no">
-    <branch module="openssl-3.2.1.tar.gz" version="3.2.1" repo="openssl"
-            hash="sha256:83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39"/>
+    <branch module="openssl/openssl/releases/download/openssl-3.3.1/openssl-3.3.1.tar.gz"
+            version="3.3.1"
+            hash="sha256:777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e"
+            repo="github-tarball"/>
   </autotools>
   <!--
     Rudely demands TeX to build documentation


### PR DESCRIPTION
Just released yesterday - build and runtime tested without any problems here.

This also switches to github for the source download, as it seems more up to date than openssl.org