### PR TITLE
Add libhandy 1.8 and libadwaita 1.6.5 to gtk-osx-random.modules.

### DIFF
--- a/modulesets-stable/gtk-osx-random.modules
+++ b/modulesets-stable/gtk-osx-random.modules
@@ -12,6 +12,9 @@
   <repository name="github-tarball"
               href="https://github.com/"
               type="tarball" />
+  <repository name="github"
+              href="https://github.com/"
+              type="git" />
   <repository name="ftp.gnu.org"
               href="https://ftp.gnu.org/gnu/"
               type="tarball" />
@@ -262,5 +265,63 @@
     <dependencies>
       <dep package="libxml2" />
     </dependencies>
+  </autotools>
+  <meson id="libhandy"
+         mesonargs="-Dvapi=false">
+    <branch module="libhandy/1.8/libhandy-1.8.3.tar.xz"
+            version="1.8.3"
+            hash="sha256:05b497229073ff557f10b326e074c5066f8743a302d4820ab97bcb5cd2dab087" />
+    <dependencies>
+      <dep package="gtk+-3.0" />
+    </dependencies>
+  </meson>
+  <meson id="libadwaita"
+         mesonargs="-Dvapi=false -Dintrospection=enabled">
+    <branch module="libadwaita/1.6/libadwaita-1.6.5.tar.xz"
+            version="1.6.5"
+            hash="sha256:d4713cfe5daeb2e537ccb6cb013c153677a3f1c29e5c166c5663e33605eb8ee2" />
+    <dependencies>
+      <dep package="gtk-4" />
+      <dep package="sassc" />
+      <dep package="appstream" />
+    </dependencies>
+  </meson>
+      <meson id="appstream"
+         mesonargs="-Dsystemd=false -Dstemming=false -Dapidocs=false -Dinstall-docs=false">
+    <branch revision="v1.0.4"
+            repo="github"
+            module="ximion/appstream" />
+    <dependencies>
+      <dep package="libcurl" />
+      <dep package="libxmlb" />
+      <dep package="libyaml" />
+      <dep package="libzstd" />
+      <dep package="itstool" />
+    </dependencies>
+  </meson>
+  <autotools id="libcurl"
+             autogen-sh="autoreconf"
+             autogenargs="--with-openssl">
+    <branch revision="curl-8_13_0"
+            repo="github"
+            module="curl/curl" />
+  </autotools>
+  <meson id="libxmlb">
+    <branch revision="0.3.22"
+            repo="github"
+            module="hughsie/libxmlb" />
+  </meson>
+  <autotools id="libyaml"
+             autogen-sh="autoreconf">
+    <branch revision="0.2.5"
+            repo="github"
+            module="yaml/libyaml" />
+  </autotools>
+  <autotools id="libzstd"
+             skip-autogen="true"
+             supports-non-srcdir-builds="no">
+    <branch revision="v1.5.7"
+            repo="github"
+            module="facebook/zstd" />
   </autotools>
 </moduleset>

--- a/modulesets-unstable/gtk-osx-random.modules
+++ b/modulesets-unstable/gtk-osx-random.modules
@@ -253,4 +253,85 @@
       <dep package="libxml2" />
     </dependencies>
   </autotools>
+  <!---->
+  <meson id="libhandy"
+         mesonargs="-Dvapi=false">
+    <branch revision="libhandy-1-8"
+            repo="git.gnome.org" />
+    <dependencies>
+      <dep package="gtk+-3.0" />
+    </dependencies>
+  </meson>
+  <!---->
+  <meson id="libadwaita"
+         mesonargs="-Dvapi=false -Dintrospection=enabled">
+    <branch revision="1.6.5"
+            repo="git.gnome.org" />
+    <dependencies>
+      <dep package="gtk-4" />
+      <dep package="sassc" />
+      <dep package="appstream" />
+    </dependencies>
+  </meson>
+  <!---->
+  <autotools id="sassc"
+             autogen-sh="autoreconf">
+    <branch revision="3.6.2"
+            repo="github"
+            module="sass/sassc" />
+    <dependencies>
+      <dep package="libsass" />
+    </dependencies>
+  </autotools>
+  <!---->
+  <autotools id="libsass"
+             autogen-sh="autoreconf"
+             autogenargs="--disable-tests --disable-shared">
+    <branch revision="3.6.6"
+            repo="github"
+            module="sass/libsass" />
+  </autotools>
+  <!---->
+  <meson id="appstream"
+         mesonargs="-Dsystemd=false -Dstemming=false -Dapidocs=false -Dinstall-docs=false">
+    <branch revision="v1.0.4"
+            repo="github"
+            module="ximion/appstream" />
+    <dependencies>
+      <dep package="libcurl" />
+      <dep package="libxmlb" />
+      <dep package="libyaml" />
+      <dep package="libzstd" />
+      <dep package="itstool" />
+    </dependencies>
+  </meson>
+  <!---->
+  <autotools id="libcurl"
+             autogen-sh="autoreconf"
+             autogenargs="--with-openssl">
+    <branch revision="curl-8_13_0"
+            repo="github"
+            module="curl/curl" />
+  </autotools>
+  <!---->
+  <meson id="libxmlb">
+    <branch revision="0.3.22"
+            repo="github"
+            module="hughsie/libxmlb" />
+  </meson>
+  <!---->
+  <autotools id="libyaml"
+             autogen-sh="autoreconf">
+    <branch revision="0.2.5"
+            repo="github"
+            module="yaml/libyaml" />
+  </autotools>
+  <!---->
+  <autotools id="libzstd"
+             skip-autogen="true"
+             supports-non-srcdir-builds="no">
+    <branch revision="v1.5.7"
+            repo="github"
+            module="facebook/zstd" />
+  </autotools>
 </moduleset>

--- a/modulesets-unstable/gtk-osx-random.modules
+++ b/modulesets-unstable/gtk-osx-random.modules
@@ -253,46 +253,23 @@
       <dep package="libxml2" />
     </dependencies>
   </autotools>
-  <!---->
   <meson id="libhandy"
          mesonargs="-Dvapi=false">
-    <branch revision="libhandy-1-8"
-            repo="git.gnome.org" />
+    <branch />
     <dependencies>
       <dep package="gtk+-3.0" />
     </dependencies>
   </meson>
-  <!---->
   <meson id="libadwaita"
          mesonargs="-Dvapi=false -Dintrospection=enabled">
-    <branch revision="1.6.5"
-            repo="git.gnome.org" />
+    <branch />
     <dependencies>
       <dep package="gtk-4" />
       <dep package="sassc" />
       <dep package="appstream" />
     </dependencies>
   </meson>
-  <!---->
-  <autotools id="sassc"
-             autogen-sh="autoreconf">
-    <branch revision="3.6.2"
-            repo="github"
-            module="sass/sassc" />
-    <dependencies>
-      <dep package="libsass" />
-    </dependencies>
-  </autotools>
-  <!---->
-  <autotools id="libsass"
-             autogen-sh="autoreconf"
-             autogenargs="--disable-tests --disable-shared">
-    <branch revision="3.6.6"
-            repo="github"
-            module="sass/libsass" />
-  </autotools>
-  <!---->
-  <meson id="appstream"
+      <meson id="appstream"
          mesonargs="-Dsystemd=false -Dstemming=false -Dapidocs=false -Dinstall-docs=false">
     <branch revision="v1.0.4"
             repo="github"
@@ -305,7 +282,6 @@
       <dep package="itstool" />
     </dependencies>
   </meson>
-  <!---->
   <autotools id="libcurl"
              autogen-sh="autoreconf"
              autogenargs="--with-openssl">
@@ -313,20 +289,17 @@
             repo="github"
             module="curl/curl" />
   </autotools>
-  <!---->
   <meson id="libxmlb">
     <branch revision="0.3.22"
             repo="github"
             module="hughsie/libxmlb" />
   </meson>
-  <!---->
   <autotools id="libyaml"
              autogen-sh="autoreconf">
     <branch revision="0.2.5"
             repo="github"
             module="yaml/libyaml" />
   </autotools>
-  <!---->
   <autotools id="libzstd"
              skip-autogen="true"
              supports-non-srcdir-builds="no">

--- a/modulesets/gtk-osx-random.modules
+++ b/modulesets/gtk-osx-random.modules
@@ -248,4 +248,58 @@
       <dep package="libxml2" />
     </dependencies>
   </autotools>
+  <meson id="libhandy"
+         mesonargs="-Dvapi=false">
+    <branch revision="1.8.3" />
+    <dependencies>
+      <dep package="gtk+-3.0" />
+    </dependencies>
+  </meson>
+  <meson id="libadwaita"
+         mesonargs="-Dvapi=false -Dintrospection=enabled">
+    <branch revision="1.6.5" />
+    <dependencies>
+      <dep package="gtk-4" />
+      <dep package="sassc" />
+      <dep package="appstream" />
+    </dependencies>
+  </meson>
+      <meson id="appstream"
+         mesonargs="-Dsystemd=false -Dstemming=false -Dapidocs=false -Dinstall-docs=false">
+    <branch revision="v1.0.4"
+            repo="github"
+            module="ximion/appstream" />
+    <dependencies>
+      <dep package="libcurl" />
+      <dep package="libxmlb" />
+      <dep package="libyaml" />
+      <dep package="libzstd" />
+      <dep package="itstool" />
+    </dependencies>
+  </meson>
+  <autotools id="libcurl"
+             autogen-sh="autoreconf"
+             autogenargs="--with-openssl">
+    <branch revision="curl-8_13_0"
+            repo="github"
+            module="curl/curl" />
+  </autotools>
+  <meson id="libxmlb">
+    <branch revision="0.3.22"
+            repo="github"
+            module="hughsie/libxmlb" />
+  </meson>
+  <autotools id="libyaml"
+             autogen-sh="autoreconf">
+    <branch revision="0.2.5"
+            repo="github"
+            module="yaml/libyaml" />
+  </autotools>
+  <autotools id="libzstd"
+             skip-autogen="true"
+             supports-non-srcdir-builds="no">
+    <branch revision="v1.5.7"
+            repo="github"
+            module="facebook/zstd" />
+  </autotools>
 </moduleset>


### PR DESCRIPTION
I add them and their dependencies in unstable modulesets.
Tell me if it is correct.
Tell me if I had to report them also on other modulesets.