### PR TITLE
libpng 1.6.52

### DIFF
--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -30,9 +30,9 @@
   <autotools id="libpng"
              autogen-sh="configure"
              autogenargs="--enable-shared">
-    <branch module="libpng/libpng-1.6.51.tar.xz"
-            version="1.6.51"
-            hash="sha256:a050a892d3b4a7bb010c3a95c7301e49656d72a64f1fc709a90b8aded192bed2"
+    <branch module="libpng/libpng-1.6.52.tar.xz"
+            version="1.6.52"
+            hash="sha256:36bd726228ec93a3b6c22fdb49e94a67b16f2fe9b39b78b7cb65772966661ccc"
             repo="sourceforge" />
     <dependencies>
       <dep package="zlib" />

--- a/modulesets-unstable/gtk-osx-bootstrap.modules
+++ b/modulesets-unstable/gtk-osx-bootstrap.modules
@@ -21,9 +21,9 @@
   <autotools id="libpng"
              autogen-sh="configure"
              autogenargs="--enable-shared">
-    <branch module="libpng/libpng-1.6.51.tar.xz"
-            version="1.6.51"
-            hash="sha256:a050a892d3b4a7bb010c3a95c7301e49656d72a64f1fc709a90b8aded192bed2"
+    <branch module="libpng/libpng-1.6.52.tar.xz"
+            version="1.6.52"
+            hash="sha256:36bd726228ec93a3b6c22fdb49e94a67b16f2fe9b39b78b7cb65772966661ccc"
             repo="sourceforge" />
     <dependencies>
       <dep package="zlib" />

--- a/modulesets/gtk-osx-bootstrap.modules
+++ b/modulesets/gtk-osx-bootstrap.modules
@@ -21,9 +21,9 @@
   <autotools id="libpng"
              autogen-sh="configure"
              autogenargs="--enable-shared">
-    <branch module="libpng/libpng-1.6.51.tar.xz"
-            version="1.6.51"
-            hash="sha256:a050a892d3b4a7bb010c3a95c7301e49656d72a64f1fc709a90b8aded192bed2"
+    <branch module="libpng/libpng-1.6.52.tar.xz"
+            version="1.6.52"
+            hash="sha256:36bd726228ec93a3b6c22fdb49e94a67b16f2fe9b39b78b7cb65772966661ccc"
             repo="sourceforge" />
     <dependencies>
       <dep package="zlib" />


### PR DESCRIPTION
Another week, another libpng vulnerability: [CVE-2025-66293](https://www.cve.org/CVERecord?id=CVE-2025-66293)
I don't really understand why it got such a high score since this one is just an "out-of-bounds read".