### PR TITLE
xz 5.8.3

### DIFF
--- a/modulesets-stable/bootstrap.modules
+++ b/modulesets-stable/bootstrap.modules
@@ -23,9 +23,9 @@
   <autotools id="xz"
              autogen-sh="configure"
              bootstrap="true">
-    <branch module="tukaani-project/xz/releases/download/v5.8.2/xz-5.8.2.tar.bz2"
-            version="5.8.2"
-            hash="sha256:60345d7c0b9c8d7ffa469e96898c300def3669f5047fc76219b819340839f3d8"
+    <branch module="tukaani-project/xz/releases/download/v5.8.3/xz-5.8.3.tar.xz"
+            version="5.8.3"
+            hash="sha256:fff1ffcf2b0da84d308a14de513a1aa23d4e9aa3464d17e64b9714bfdd0bbfb6"
             repo="github" />
   </autotools>
   <!-- gnu make 4.xx, needed to unbreak parallel builds for the webkit -->


### PR DESCRIPTION
XZ Utils 5.8.3, released on March 31, 2026, is a critical security update addressing [CVE-2026-34743](https://github.com/tukaani-project/xz/commit/c8c22869e780ff57c96b46939c3d79ff99395f87), a buffer overflow vulnerability in `lzma_index_append()` affecting all previous versions since 5.0.0. This update introduces boundary checks for `lzma_index_decoder()` to prevent memory issues.

Sounds scary, but it's probably not that big a deal.