### PR TITLE
libpng 1.6.58

### DIFF
--- a/modulesets-stable/gtk-osx-bootstrap.modules
+++ b/modulesets-stable/gtk-osx-bootstrap.modules
@@ -30,10 +30,11 @@
   <autotools id="libpng"
              autogen-sh="configure"
              autogenargs="--enable-shared">
-    <branch module="libpng/libpng-1.6.56.tar.xz"
-            version="1.6.56"
-            hash="sha256:f7d8bf1601b7804f583a254ab343a6549ca6cf27d255c302c47af2d9d36a6f18"
-            repo="sourceforge" />
+    <branch module="pnggroup/libpng/archive/refs/tags/v1.6.58.tar.gz"
+	    checkoutdir="libpng-1.6.58"
+            version="1.6.58"
+            hash="sha256:a9d4df463d36a6e5f9c29bd6f4967312d17e996c1854f3511f833924eb1993cf"
+            repo="github-tarball" />
     <dependencies>
       <dep package="zlib" />
     </dependencies>

--- a/modulesets-unstable/gtk-osx-bootstrap.modules
+++ b/modulesets-unstable/gtk-osx-bootstrap.modules
@@ -21,11 +21,11 @@
   <autotools id="libpng"
              autogen-sh="configure"
              autogenargs="--enable-shared">
-    <branch module="netwide-assembler/nasm/archive/refs/tags/nasm-3.01.tar.gz"
-            checkoutdir="nasm-nasm-3.01"
-            version="3.01"
-            hssh="sha256:af2f241ecc061205d73ba4f781f075d025dabaeab020b676b7db144bf7015d6d"
-            repo="sourceforge" />
+    <branch module="pnggroup/libpng/archive/refs/tags/v1.6.58.tar.gz"
+	    checkoutdir="libpng-1.6.58"
+            version="1.6.58"
+            hash="sha256:a9d4df463d36a6e5f9c29bd6f4967312d17e996c1854f3511f833924eb1993cf"
+            repo="github-tarball" />
     <dependencies>
       <dep package="zlib" />
     </dependencies>

--- a/modulesets/gtk-osx-bootstrap.modules
+++ b/modulesets/gtk-osx-bootstrap.modules
@@ -21,11 +21,11 @@
   <autotools id="libpng"
              autogen-sh="configure"
              autogenargs="--enable-shared">
-    <branch module="netwide-assembler/nasm/archive/refs/tags/nasm-3.01.tar.gz"
-            checkoutdir="nasm-nasm-3.01"
-            version="3.01"
-            hssh="sha256:af2f241ecc061205d73ba4f781f075d025dabaeab020b676b7db144bf7015d6d"
-            repo="sourceforge" />
+    <branch module="pnggroup/libpng/archive/refs/tags/v1.6.58.tar.gz"
+	    checkoutdir="libpng-1.6.58"
+            version="1.6.58"
+            hash="sha256:a9d4df463d36a6e5f9c29bd6f4967312d17e996c1854f3511f833924eb1993cf"
+            repo="github-tarball" />
     <dependencies>
       <dep package="zlib" />
     </dependencies>


### PR DESCRIPTION
This includes a fix for [`CVE-2026-34757`](https://www.cve.org/CVERecord?id=CVE-2026-34757).

Please be aware that `modulesets-unstable` and `modulesets` were messed up somehow as they included `nasm` instead of `libpng`!