### PR TITLE
network updates

### DIFF
--- a/modulesets-stable/gtk-osx-network.modules
+++ b/modulesets-stable/gtk-osx-network.modules
@@ -52,9 +52,9 @@
     <autotools id="libnettle"
                autogen-sh="configure"
                autogenargs="--disable-documentation --disable-assembler">
-      <branch module="nettle/nettle-3.10.2.tar.gz"
-              version="3.10.2"
-              hash="sah256:fe9ff51cb1f2abb5e65a6b8c10a92da0ab5ab6eaf26e7fc2b675c45f1fb519b5"
+      <branch module="nettle/nettle-4.0.tar.gz"
+              version="4.0"
+              hash="sha256:3addbc00da01846b232fb3bc453538ea5468da43033f21bb345cb1e9073f5094"
               repo="ftp.gnu.org" />
       <dependencies>
         <dep package="gmp" />
@@ -66,9 +66,9 @@
     <autotools id="libnettle"
                autogen-sh="configure"
                autogenargs="--disable-documentation">
-      <branch module="nettle/nettle-3.10.2.tar.gz"
-              version="3.10.2"
-              hash="sah256:fe9ff51cb1f2abb5e65a6b8c10a92da0ab5ab6eaf26e7fc2b675c45f1fb519b5"
+      <branch module="nettle/nettle-4.0.tar.gz"
+              version="4.0"
+              hash="sha256:3addbc00da01846b232fb3bc453538ea5468da43033f21bb345cb1e9073f5094"
               repo="ftp.gnu.org" />
       <dependencies>
         <dep package="gmp" />
@@ -108,9 +108,9 @@
   <autotools id="gnutls"
              autogen-sh="autoreconf"
              autogenargs="--disable-doc --with-included-unistring">
-    <branch module="gcrypt/gnutls/v3.8/gnutls-3.8.12.tar.xz"
-            version="3.8.12"
-            hash="sha256:a7b341421bfd459acf7a374ca4af3b9e06608dcd7bd792b2bf470bea012b8e51"
+    <branch module="gcrypt/gnutls/v3.8/gnutls-3.8.13.tar.xz"
+            version="3.8.13"
+            hash="sha256:ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e"
             repo="gnupg.org">
       <patch file="gnutls-gnulib.patch"
              strip="1" />
@@ -127,16 +127,16 @@
   <autotools id="libgpg-error"
              autogen-sh="autoreconf"
              autogenargs="--disable-doc">
-    <branch module="gcrypt/libgpg-error/libgpg-error-1.59.tar.bz2"
-            version="1.59"
-            hash="sha256:a19bc5087fd97026d93cb4b45d51638d1a25202a5e1fbc3905799f424cfa6134"
+    <branch module="gcrypt/libgpg-error/libgpg-error-1.61.tar.bz2"
+            version="1.61"
+            hash="sha256:7a85413f2bc354f4f8aa832b718af122e48965e9e0eb9012ee659c13c6385c93"
             repo="gnupg.org" />
   </autotools>
   <autotools id="libgcrypt"
              autogen-sh="configure">
-    <branch module="gcrypt/libgcrypt/libgcrypt-1.12.1.tar.bz2"
-            version="1.12.1"
-            hash="sha256:7df5c08d952ba33f9b6bdabdb06a61a78b2cf62d2122c2d1d03a91a79832aa3c"
+    <branch module="gcrypt/libgcrypt/libgcrypt-1.12.2.tar.bz2"
+            version="1.12.2"
+            hash="sha256:7ce33c2492221a0436f96a8500215e9f3e3dcb5fd26a757cd415e7a843babd5e"
             repo="gnupg.org" />
     <dependencies>
       <dep package="libgpg-error" />
@@ -223,9 +223,9 @@
   </meson>
   <cmake id="libnghttp2"
          cmakeargs='-DENABLE_LIB_ONLY=ON -DENABLE_DOC=OFF -DWITH_LIBXML2=OFF -DWITH_JEMALLOC=OFF -DWITH_MRUBY=OFF -DWITH_NEVERBLEED=OFF -DWITH_LIBBPF=OFF -DCMAKE_INSTALL_NAME_DIR="${JHBUILD_PREFIX}/lib"'>
-    <branch module="nghttp2/nghttp2/releases/download/v1.68.1/nghttp2-1.68.1.tar.xz"
-            version="1.68.1"
-            hash="sha256:6abd7ab0a7f1580d5914457cb3c85eb80455657ee5119206edbd7f848c14f0b2"
+    <branch module="nghttp2/nghttp2/releases/download/v1.69.0/nghttp2-1.69.0.tar.xz"
+            version="1.69.0"
+            hash="sha256:1fb324b6ec2c56f6bde0658f4139ffd8209fa9e77ce98fd7a5f63af8d0e508ad"
             repo="github-tarball" />
     <dependencies>
       <dep package="openssl" />

--- a/modulesets-unstable/gtk-osx-network.modules
+++ b/modulesets-unstable/gtk-osx-network.modules
@@ -96,10 +96,10 @@
   <autotools id="gnutls"
              autogen-sh="autoreconf"
              autogenargs="--disable-doc --with-included-unistring">
-    <branch module="gcrypt/gnutls/v3.8/gnutls-3.8.12.tar.xz"
-            version="3.8.12"
+    <branch module="gcrypt/gnutls/v3.8/gnutls-3.8.13.tar.xz"
+            version="3.8.13"
 
-            repo="gnupg.org">
+            repo="gnupg.org" hash="sha256:ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e">
       <patch file="gnutls-pkg-config-pc.patch"
              strip="1" />
       <patch file="gnutls-gnulib.patch"

--- a/modulesets/gtk-osx-network.modules
+++ b/modulesets/gtk-osx-network.modules
@@ -58,9 +58,9 @@
     <autotools id="libnettle"
                autogen-sh="configure"
                autogenargs="--disable-documentation --disable-assembler">
-      <branch module="nettle/nettle-3.10.2.tar.gz"
-              version="3.10.2"
-              hash="sah256:fe9ff51cb1f2abb5e65a6b8c10a92da0ab5ab6eaf26e7fc2b675c45f1fb519b5"
+      <branch module="nettle/nettle-4.0.tar.gz"
+              version="4.0"
+              hash="sha256:3addbc00da01846b232fb3bc453538ea5468da43033f21bb345cb1e9073f5094"
               repo="ftp.gnu.org" />
       <dependencies>
         <dep package="gmp" />
@@ -72,9 +72,9 @@
     <autotools id="libnettle"
                autogen-sh="configure"
                autogenargs="--disable-documentation">
-      <branch module="nettle/nettle-3.10.1.tar.gz"
-              version="3.10.2"
-              hash="sah256:fe9ff51cb1f2abb5e65a6b8c10a92da0ab5ab6eaf26e7fc2b675c45f1fb519b5"
+      <branch module="nettle/nettle-4.0.tar.gz"
+              version="4.0"
+              hash="sha256:3addbc00da01846b232fb3bc453538ea5468da43033f21bb345cb1e9073f5094"
               repo="ftp.gnu.org" />
       <dependencies>
         <dep package="gmp" />
@@ -119,9 +119,9 @@
   <autotools id="gnutls"
              autogen-sh="autoreconf"
              autogenargs="--disable-doc --with-included-unistring">
-    <branch module="gcrypt/gnutls/v3.8/gnutls-3.8.12.tar.xz"
-            version="3.8.12"
-            hash="sha256:a7b341421bfd459acf7a374ca4af3b9e06608dcd7bd792b2bf470bea012b8e51"
+    <branch module="gcrypt/gnutls/v3.8/gnutls-3.8.13.tar.xz"
+            version="3.8.13"
+            hash="sha256:ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e"
             repo="gnupg.org">
       <patch file="gnutls-pkg-config-pc.patch"
              strip="1" />


### PR DESCRIPTION
Includes:
* `nghttp2-1.69.0` addresses [`CVE-2026-27135`](https://github.com/nghttp2/nghttp2/security/advisories/GHSA-6933-cjhr-5qg6) assertion failure, meh
* `gnutls-3.8.13` 12 CVEs - yikes: https://gnutls.org/
* `libgcrypt-1.12.2`: [`CVE-2026-41989`](https://nvd.nist.gov/vuln/detail/CVE-2026-41989) [`CVE-2026-41990`](https://nvd.nist.gov/vuln/detail/CVE-2026-41990)